### PR TITLE
feat: simple release binary size optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,9 @@ rayon = "1.10.0"
 assert_cmd = "2.0"
 predicates = "3.1"
 tempfile = "3.10"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
This change for the release build enables:
- Link Time Optimization (LTO) which drops some of the dead code
- Forces Rust to use 1 codegen unit for maximum code optimization regarding size and speed
- Removes stack unwinding. Meaning there is no stack trace on panic.

These settings reduced the size of release build from 4.3M to 2.9M on my machine.