### PR TITLE
fix: remove redundant dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,6 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
- "crossterm",
  "git2",
  "ignore",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["command-line-utilities", "filesystem"]
 anyhow = "1.0"
 colored = "2.1.0"
 clap = { version = "4.5.7", features = ["derive"] }
-crossterm = "0.27.0"
 git2 = "0.19.0"
 ignore = "0.4.22"
 ratatui = "0.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["command-line-utilities", "filesystem"]
 anyhow = "1.0"
 colored = "2.1.0"
 clap = { version = "4.5.7", features = ["derive"] }
-crossterm = "0.27.0"
 git2 = { version = "0.20.2", default-features = false }
 ignore = "0.4.22"
 ratatui = "0.27.0"

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7,7 +7,7 @@ use crate::app::InteractiveArgs;
 use crate::git::{self, StatusCache};
 use crate::icons;
 use crate::utils;
-use crossterm::{
+use ratatui::crossterm::{
     event::{
         self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
     },

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7,6 +7,7 @@ use crate::app::InteractiveArgs;
 use crate::git::{self, StatusCache};
 use crate::icons;
 use crate::utils;
+use ignore::WalkBuilder;
 use ratatui::crossterm::{
     event::{
         self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
@@ -14,7 +15,6 @@ use ratatui::crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ignore::WalkBuilder;
 use ratatui::{
     backend::{Backend, CrosstermBackend},
     style::{Color, Modifier, Style},


### PR DESCRIPTION
Remove `crossterm` from dependency list. `crossterm` is already reexported in ratatui crate. Having two direct dependencies like that, can create a version mismatch in the feature as rust treats every version of every code in the crate as different.