### PR TITLE
Fix: Remove \\?\ prefix from displayed path on Windows

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -321,7 +321,13 @@ pub fn run(args: &InteractiveArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
             Command::new(editor).arg(path).status()?;
         }
         PostExitAction::PrintPath(path) => {
-            let display_path = path.clone().display().to_string().replace(r"\\?\", "");
+            let path_string = path.display().to_string();
+            let display_path = if path_string.len() <= 260 {
+                path_string.replace(r"\\?\", "")
+            } else {
+                // Keep \\?\ when it exceeds 260 characters. to avoid potential problems.
+                path_string
+            };
             println!("{}", display_path);
         }
         PostExitAction::None => {}


### PR DESCRIPTION
This PR addresses Issue #24 by improving the readability of file paths printed in interactive mode on Windows.

This change strips the prefix when displaying the path via `PostExitAction::PrintPath`, ensuring a clean and intuitive output.

- Note: Although the diff shows 44 lines changed, only 2 lines were functionally modified. The rest are due to auto-formatting for consistency.

Happy to revise based on feedback!
