### PR TITLE
add close encompassing folder with keybinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `h`/`←` (collapse selected or parent directory) and `l`/`→` (expand/open) navigation keys in interactive mode ([Closes #41](https://github.com/bgreenwell/lstr/issues/41), thanks @Kr1ngl3)
 - Directories now show the most severe git status of their contents with `-G`, in both classic and interactive modes
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ Launch the TUI with `lstr interactive [OPTIONS] [PATH]`.
 | :------ | :------------------------------------------------------------------------------------------------------------------------------------------ |
 | `↑` / `k` | Move selection up. |
 | `↓` / `j` | Move selection down. |
+| `←` / `h` | Collapse the selected directory, or jump to and collapse its parent. |
+| `→` / `l` | Same as `Enter`. |
 | `Enter` | **Context-aware action:**<br>- If on a file: Open it in the default editor (`$EDITOR`).<br>- If on a directory: Toggle expand/collapse. |
+| `/` | Search: filter entries by name as you type. `Esc` exits search. |
 | `q` / `Esc` | Quit the application normally. |
 | `Ctrl`+`s` | **Shell integration:** Quits and prints the selected path to stdout. |
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -191,6 +191,34 @@ impl AppState {
         self.list_state.selected().and_then(|i| self.visible_entries.get(i))
     }
 
+    fn close_encompassing_directory(&mut self) {
+        if let Some(selected_index) = self.list_state.selected() {
+            let selected_path = self.visible_entries[selected_index].path.clone();
+            if let Some(master_entry) =
+                self.master_entries.iter_mut().find(|e| e.path == selected_path)
+            {
+                if master_entry.is_dir && master_entry.is_expanded {
+                    master_entry.is_expanded = false;
+                } else if let Some(parent_entry) = self
+                    .master_entries
+                    .iter_mut()
+                    .find(|e| e.path == selected_path.parent().unwrap())
+                {
+                    parent_entry.is_expanded = false;
+                }
+            }
+            self.regenerate_visible_entries();
+            if let Some(new_index) =
+                self.visible_entries.iter().position(|e| e.path == selected_path.parent().unwrap())
+            {
+                self.list_state.select(Some(new_index));
+            } else {
+                let new_selection = selected_index.min(self.visible_entries.len() - 1);
+                self.list_state.select(Some(new_selection));
+            }
+        }
+    }
+
     fn toggle_selected_directory(&mut self) {
         if let Some(selected_index) = self.list_state.selected() {
             let selected_path = self.visible_entries[selected_index].path.clone();
@@ -370,7 +398,10 @@ fn run_app<B: Backend + Write>(
                     }
                     KeyCode::Down | KeyCode::Char('j') => app_state.next(),
                     KeyCode::Up | KeyCode::Char('k') => app_state.previous(),
-                    KeyCode::Enter => {
+                    KeyCode::Left | KeyCode::Char('h') => {
+                        app_state.close_encompassing_directory();
+                    }
+                    KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
                         if let Some(entry) = app_state.get_selected_entry() {
                             if entry.is_dir {
                                 app_state.toggle_selected_directory();


### PR DESCRIPTION
keybind to close encompassing folder with 'h' or left arrow. 
Also add extra keybinds for toggle current folder with 'l' and right arrow #41 

Closing encompassing folder also moves cursor or selected entry to the just closed folder (as the previously selected file is now visible any longer)