### PR TITLE
Fix CI gates, terminal restore, and TUI search handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the interactive TUI quitting when typing `q` (or other command keys) into a search query
+- Fixed a crash when navigating an empty directory or empty search results in interactive mode
+- Fixed the terminal being left in raw mode on the alternate screen when the TUI exited with an error or panic
+- Fixed expanding a directory during search corrupting the restored file list; search mode now exits before toggling
+- Fixed search rejecting printable punctuation characters (e.g. `+`, `#`, `(`) in filenames
+- Fixed the selection jumping to an unrelated entry after exiting search mode
+
 - **CRITICAL**: Fixed fundamental tree structure corruption caused by flat sorting destroying parent-child relationships. Implemented tree-aware hierarchical sorting that preserves proper tree traversal order while sorting siblings within their respective parent directories. This resolves multiple cascading issues:
   - Fixed tree display connector issue where all entries showed `└──` instead of proper mixed `├──` and `└──` connectors ([Closes #36](https://github.com/bgreenwell/lstr/issues/36))
   - Fixed incorrect file nesting where children appeared under wrong parents or in jumbled order

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -8,9 +8,10 @@ use std::cmp::Ordering;
 use std::ffi::OsStr;
 
 /// Defines the available sorting strategies.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SortType {
     /// Sort by name (default)
+    #[default]
     Name,
     /// Sort by file size
     Size,
@@ -18,12 +19,6 @@ pub enum SortType {
     Modified,
     /// Sort by file extension
     Extension,
-}
-
-impl Default for SortType {
-    fn default() -> Self {
-        Self::Name
-    }
 }
 
 /// Configuration options for sorting directory entries.
@@ -79,53 +74,50 @@ pub fn sort_entries(entries: &mut [DirEntry], options: &SortOptions) {
 }
 
 /// Sorts directory entries hierarchically, preserving tree structure.
-/// 
+///
 /// This builds an explicit tree structure and then reconstructs the entries
 /// in depth-first order with proper sibling sorting within each parent directory.
 /// Use this instead of sort_entries() when you need to preserve parent-child relationships.
 pub fn sort_entries_hierarchically(entries: &mut Vec<DirEntry>, options: &SortOptions) {
     use std::collections::HashMap;
-    
+
     if entries.is_empty() {
         return;
     }
-    
+
     // Build parent-child mapping
     let mut children_map: HashMap<std::path::PathBuf, Vec<DirEntry>> = HashMap::new();
     let mut all_entries_by_path: HashMap<std::path::PathBuf, DirEntry> = HashMap::new();
-    
+
     // Collect all entries and build parent-child relationships
     for entry in entries.iter() {
         all_entries_by_path.insert(entry.path().to_path_buf(), entry.clone());
-        
+
         if let Some(parent_path) = entry.path().parent() {
             children_map.entry(parent_path.to_path_buf()).or_default().push(entry.clone());
         }
     }
-    
+
     // Sort children within each parent directory
     for children in children_map.values_mut() {
         sort_entries(children, options);
     }
-    
+
     // Find root entries (depth 1, since we skip depth 0)
-    let mut root_entries: Vec<_> = entries.iter()
-        .filter(|e| e.depth() == 1)
-        .cloned()
-        .collect();
-    
+    let mut root_entries: Vec<_> = entries.iter().filter(|e| e.depth() == 1).cloned().collect();
+
     // Sort root entries
     sort_entries(&mut root_entries, options);
-    
+
     // Recursively collect entries in depth-first order
     fn collect_tree_entries(
         entry: &DirEntry,
         children_map: &HashMap<std::path::PathBuf, Vec<DirEntry>>,
-        result: &mut Vec<DirEntry>
+        result: &mut Vec<DirEntry>,
     ) {
         // Add the parent entry
         result.push(entry.clone());
-        
+
         // Add all its children in sorted order
         if let Some(children) = children_map.get(entry.path()) {
             for child in children {
@@ -133,13 +125,13 @@ pub fn sort_entries_hierarchically(entries: &mut Vec<DirEntry>, options: &SortOp
             }
         }
     }
-    
+
     // Rebuild entries in proper tree order
     let mut result = Vec::new();
     for root in &root_entries {
         collect_tree_entries(root, &children_map, &mut result);
     }
-    
+
     *entries = result;
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -13,7 +13,8 @@ use lscolors::{Color as LsColor, LsColors, Style as LsStyle};
 use ratatui::crossterm::{
     cursor,
     event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+        KeyModifiers,
     },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -161,6 +162,10 @@ impl AppState {
     }
 
     fn next(&mut self) {
+        if self.visible_entries.is_empty() {
+            self.list_state.select(None);
+            return;
+        }
         let i = match self.list_state.selected() {
             Some(i) => {
                 if i >= self.visible_entries.len() - 1 {
@@ -175,6 +180,10 @@ impl AppState {
     }
 
     fn previous(&mut self) {
+        if self.visible_entries.is_empty() {
+            self.list_state.select(None);
+            return;
+        }
         let i = match self.list_state.selected() {
             Some(i) => {
                 if i == 0 {
@@ -194,7 +203,11 @@ impl AppState {
 
     fn toggle_selected_directory(&mut self) {
         if let Some(selected_index) = self.list_state.selected() {
-            let selected_path = self.visible_entries[selected_index].path.clone();
+            let Some(selected_path) =
+                self.visible_entries.get(selected_index).map(|e| e.path.clone())
+            else {
+                return;
+            };
             if let Some(master_entry) =
                 self.master_entries.iter_mut().find(|e| e.path == selected_path)
             {
@@ -207,10 +220,19 @@ impl AppState {
                 self.visible_entries.iter().position(|e| e.path == selected_path)
             {
                 self.list_state.select(Some(new_index));
+            } else if self.visible_entries.is_empty() {
+                self.list_state.select(None);
             } else {
                 let new_selection = selected_index.min(self.visible_entries.len() - 1);
                 self.list_state.select(Some(new_selection));
             }
+        }
+    }
+
+    /// Selects the entry with the given path, if it is currently visible.
+    fn select_path(&mut self, path: &Path) {
+        if let Some(index) = self.visible_entries.iter().position(|e| e.path == path) {
+            self.list_state.select(Some(index));
         }
     }
 
@@ -226,22 +248,17 @@ impl AppState {
     /// Exit search/filter mode and restore original view
     fn exit_search_mode(&mut self) {
         if self.search_mode != SearchMode::None {
-            self.visible_entries = self.original_visible_entries.clone();
-            self.original_visible_entries.clear();
+            let selected_path = self.get_selected_entry().map(|e| e.path.clone());
+            self.visible_entries = std::mem::take(&mut self.original_visible_entries);
             self.search_mode = SearchMode::None;
             self.search_query.clear();
 
-            // Restore selection to valid index
-            if let Some(selected) = self.list_state.selected() {
-                if selected >= self.visible_entries.len() {
-                    let new_selection = if self.visible_entries.is_empty() {
-                        None
-                    } else {
-                        Some(self.visible_entries.len() - 1)
-                    };
-                    self.list_state.select(new_selection);
-                }
-            }
+            // Keep the entry that was highlighted in the filtered list
+            // selected in the restored list.
+            let selection = selected_path
+                .and_then(|path| self.visible_entries.iter().position(|e| e.path == path))
+                .or(if self.visible_entries.is_empty() { None } else { Some(0) });
+            self.list_state.select(selection);
         }
     }
 
@@ -289,11 +306,13 @@ impl AppState {
                 .collect();
         }
 
-        // Reset selection to first item if current selection is out of bounds
-        if let Some(selected) = self.list_state.selected() {
-            if selected >= self.visible_entries.len() {
-                let new_selection = if self.visible_entries.is_empty() { None } else { Some(0) };
-                self.list_state.select(new_selection);
+        // Keep the selection in bounds; select the first match when the
+        // previous selection is gone (or reappears after a backspace).
+        match self.list_state.selected() {
+            Some(selected) if selected < self.visible_entries.len() => {}
+            _ => {
+                let selection = if self.visible_entries.is_empty() { None } else { Some(0) };
+                self.list_state.select(selection);
             }
         }
     }
@@ -342,53 +361,65 @@ fn run_app<B: Backend + Write>(
 
         if let Event::Key(key) = event::read()? {
             if key.kind == KeyEventKind::Press {
-                match key.code {
-                    KeyCode::Char('s') if key.modifiers == KeyModifiers::CONTROL => {
-                        if let Some(entry) = app_state.get_selected_entry() {
-                            break Ok(PostExitAction::PrintPath(entry.path.clone()));
-                        }
-                    }
-                    KeyCode::Char('q') => {
-                        break Ok(PostExitAction::None);
-                    }
-                    KeyCode::Esc => {
-                        if app_state.in_search_mode() {
-                            app_state.exit_search_mode();
-                        } else {
-                            break Ok(PostExitAction::None);
-                        }
-                    }
-                    KeyCode::Char('/') if !app_state.in_search_mode() => {
-                        app_state.enter_search_mode();
-                    }
-                    KeyCode::Backspace if app_state.in_search_mode() => {
-                        app_state.remove_from_query();
-                    }
-                    KeyCode::Char(c)
-                        if app_state.in_search_mode()
-                            && (c.is_alphanumeric()
-                                || c == '.'
-                                || c == '_'
-                                || c == '-'
-                                || c == ' ') =>
-                    {
-                        app_state.append_to_query(c);
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => app_state.next(),
-                    KeyCode::Up | KeyCode::Char('k') => app_state.previous(),
-                    KeyCode::Enter => {
-                        if let Some(entry) = app_state.get_selected_entry() {
-                            if entry.is_dir {
-                                app_state.toggle_selected_directory();
-                            } else {
-                                break Ok(PostExitAction::OpenFile(entry.path.clone()));
-                            }
-                        }
-                    }
-                    _ => {}
+                if let Some(action) = handle_key(app_state, key) {
+                    break Ok(action);
                 }
             }
         }
+    }
+}
+
+/// Processes a single key press, returning `Some` when the TUI should exit.
+fn handle_key(app_state: &mut AppState, key: KeyEvent) -> Option<PostExitAction> {
+    if key.code == KeyCode::Char('s') && key.modifiers == KeyModifiers::CONTROL {
+        return app_state.get_selected_entry().map(|e| PostExitAction::PrintPath(e.path.clone()));
+    }
+
+    // Search-mode input is handled first so that typed characters go into
+    // the query instead of triggering command keys like 'q', 'j', or 'k'.
+    if app_state.in_search_mode() {
+        match key.code {
+            KeyCode::Esc => app_state.exit_search_mode(),
+            KeyCode::Backspace => app_state.remove_from_query(),
+            KeyCode::Down => app_state.next(),
+            KeyCode::Up => app_state.previous(),
+            KeyCode::Enter => return handle_enter(app_state),
+            KeyCode::Char(c)
+                if !c.is_control() && (key.modifiers - KeyModifiers::SHIFT).is_empty() =>
+            {
+                app_state.append_to_query(c);
+            }
+            _ => {}
+        }
+        return None;
+    }
+
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => return Some(PostExitAction::None),
+        KeyCode::Char('/') => app_state.enter_search_mode(),
+        KeyCode::Down | KeyCode::Char('j') => app_state.next(),
+        KeyCode::Up | KeyCode::Char('k') => app_state.previous(),
+        KeyCode::Enter => return handle_enter(app_state),
+        _ => {}
+    }
+    None
+}
+
+/// Handles Enter on the selected entry: toggles directories, opens files.
+fn handle_enter(app_state: &mut AppState) -> Option<PostExitAction> {
+    let entry = app_state.get_selected_entry()?;
+    let (path, is_dir) = (entry.path.clone(), entry.is_dir);
+    if is_dir {
+        // Expanding changes which entries exist, so leave search mode
+        // (restoring the full list) before toggling.
+        if app_state.in_search_mode() {
+            app_state.exit_search_mode();
+            app_state.select_path(&path);
+        }
+        app_state.toggle_selected_directory();
+        None
+    } else {
+        Some(PostExitAction::OpenFile(path))
     }
 }
 
@@ -695,5 +726,123 @@ mod tests {
         let selected = app_state.get_selected_entry();
         assert!(selected.is_some());
         assert_eq!(selected.unwrap().path, PathBuf::from("README.md"));
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn empty_app_state() -> AppState {
+        AppState {
+            master_entries: Vec::new(),
+            visible_entries: Vec::new(),
+            list_state: ListState::default(),
+            search_mode: SearchMode::None,
+            search_query: String::new(),
+            original_visible_entries: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_navigation_on_empty_list_does_not_panic() {
+        let mut app_state = empty_app_state();
+        app_state.next();
+        app_state.next();
+        assert_eq!(app_state.list_state.selected(), None);
+        app_state.previous();
+        app_state.previous();
+        assert_eq!(app_state.list_state.selected(), None);
+    }
+
+    #[test]
+    fn test_quit_key_outside_search_mode() {
+        let mut app_state = setup_test_app_state();
+        let action = handle_key(&mut app_state, key(KeyCode::Char('q')));
+        assert!(matches!(action, Some(PostExitAction::None)));
+    }
+
+    #[test]
+    fn test_typing_q_in_search_mode_does_not_quit() {
+        let mut app_state = setup_test_app_state();
+        assert!(handle_key(&mut app_state, key(KeyCode::Char('/'))).is_none());
+        assert!(app_state.in_search_mode());
+        let action = handle_key(&mut app_state, key(KeyCode::Char('q')));
+        assert!(action.is_none());
+        assert_eq!(app_state.search_query, "q");
+    }
+
+    #[test]
+    fn test_search_accepts_punctuation_characters() {
+        let mut app_state = setup_test_app_state();
+        handle_key(&mut app_state, key(KeyCode::Char('/')));
+        for c in ['c', '+', '#', '('] {
+            handle_key(&mut app_state, key(KeyCode::Char(c)));
+        }
+        assert_eq!(app_state.search_query, "c+#(");
+    }
+
+    #[test]
+    fn test_ctrl_s_in_search_mode_prints_path() {
+        let mut app_state = setup_test_app_state();
+        handle_key(&mut app_state, key(KeyCode::Char('/')));
+        let ctrl_s = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL);
+        let action = handle_key(&mut app_state, ctrl_s);
+        assert!(matches!(action, Some(PostExitAction::PrintPath(_))));
+        // The modified 's' must not have been typed into the query.
+        assert_eq!(app_state.search_query, "");
+    }
+
+    #[test]
+    fn test_navigating_empty_search_results_does_not_panic() {
+        let mut app_state = setup_test_app_state();
+        handle_key(&mut app_state, key(KeyCode::Char('/')));
+        for c in ['z', 'z', 'z'] {
+            handle_key(&mut app_state, key(KeyCode::Char(c)));
+        }
+        assert!(app_state.visible_entries.is_empty());
+        assert!(handle_key(&mut app_state, key(KeyCode::Down)).is_none());
+        assert!(handle_key(&mut app_state, key(KeyCode::Down)).is_none());
+        assert!(handle_key(&mut app_state, key(KeyCode::Up)).is_none());
+        assert_eq!(app_state.list_state.selected(), None);
+        // Enter with nothing selected is a no-op, not a crash or an exit.
+        assert!(handle_key(&mut app_state, key(KeyCode::Enter)).is_none());
+    }
+
+    #[test]
+    fn test_enter_on_directory_during_search_exits_search_and_toggles() {
+        let mut app_state = setup_test_app_state();
+        handle_key(&mut app_state, key(KeyCode::Char('/')));
+        for c in ['s', 'r', 'c'] {
+            handle_key(&mut app_state, key(KeyCode::Char(c)));
+        }
+        assert_eq!(app_state.visible_entries.len(), 1);
+        assert!(handle_key(&mut app_state, key(KeyCode::Enter)).is_none());
+        assert!(!app_state.in_search_mode());
+        // Full list restored with the directory expanded and still selected.
+        assert_eq!(app_state.visible_entries.len(), 3);
+        assert_eq!(app_state.visible_entries[1].path, PathBuf::from("src/main.rs"));
+        assert_eq!(app_state.get_selected_entry().unwrap().path, PathBuf::from("src"));
+    }
+
+    #[test]
+    fn test_exit_search_restores_selection_by_path() {
+        let mut app_state = setup_test_app_state();
+        handle_key(&mut app_state, key(KeyCode::Char('/')));
+        for c in ['r', 'e', 'a', 'd'] {
+            handle_key(&mut app_state, key(KeyCode::Char(c)));
+        }
+        assert_eq!(app_state.visible_entries.len(), 1);
+        assert_eq!(app_state.get_selected_entry().unwrap().path, PathBuf::from("README.md"));
+        handle_key(&mut app_state, key(KeyCode::Esc));
+        assert!(!app_state.in_search_mode());
+        assert_eq!(app_state.visible_entries.len(), 2);
+        assert_eq!(app_state.get_selected_entry().unwrap().path, PathBuf::from("README.md"));
+    }
+
+    #[test]
+    fn test_esc_outside_search_mode_quits() {
+        let mut app_state = setup_test_app_state();
+        let action = handle_key(&mut app_state, key(KeyCode::Esc));
+        assert!(matches!(action, Some(PostExitAction::None)));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -222,7 +222,6 @@ impl AppState {
         self.search_query.clear();
     }
 
-
     /// Exit search/filter mode and restore original view
     fn exit_search_mode(&mut self) {
         if self.search_mode != SearchMode::None {
@@ -230,7 +229,7 @@ impl AppState {
             self.original_visible_entries.clear();
             self.search_mode = SearchMode::None;
             self.search_query.clear();
-            
+
             // Restore selection to valid index
             if let Some(selected) = self.list_state.selected() {
                 if selected >= self.visible_entries.len() {
@@ -274,10 +273,12 @@ impl AppState {
         } else {
             // Filter entries based on search query (case-insensitive filename match)
             let query_lower = self.search_query.to_lowercase();
-            self.visible_entries = self.original_visible_entries
+            self.visible_entries = self
+                .original_visible_entries
                 .iter()
                 .filter(|entry| {
-                    entry.path
+                    entry
+                        .path
                         .file_name()
                         .and_then(|name| name.to_str())
                         .map(|name| name.to_lowercase().contains(&query_lower))
@@ -286,15 +287,11 @@ impl AppState {
                 .cloned()
                 .collect();
         }
-        
+
         // Reset selection to first item if current selection is out of bounds
         if let Some(selected) = self.list_state.selected() {
             if selected >= self.visible_entries.len() {
-                let new_selection = if self.visible_entries.is_empty() {
-                    None
-                } else {
-                    Some(0)
-                };
+                let new_selection = if self.visible_entries.is_empty() { None } else { Some(0) };
                 self.list_state.select(new_selection);
             }
         }
@@ -365,7 +362,14 @@ fn run_app<B: Backend + Write>(
                     KeyCode::Backspace if app_state.in_search_mode() => {
                         app_state.remove_from_query();
                     }
-                    KeyCode::Char(c) if app_state.in_search_mode() && (c.is_alphanumeric() || c == '.' || c == '_' || c == '-' || c == ' ') => {
+                    KeyCode::Char(c)
+                        if app_state.in_search_mode()
+                            && (c.is_alphanumeric()
+                                || c == '.'
+                                || c == '_'
+                                || c == '-'
+                                || c == ' ') =>
+                    {
                         app_state.append_to_query(c);
                     }
                     KeyCode::Down | KeyCode::Char('j') => app_state.next(),
@@ -458,8 +462,8 @@ fn ui(f: &mut Frame, app_state: &mut AppState, args: &InteractiveArgs, ls_colors
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(0),     // Main area (flexible)
-            Constraint::Length(1),  // Status line (1 row)
+            Constraint::Min(0),    // Main area (flexible)
+            Constraint::Length(1), // Status line (1 row)
         ])
         .split(f.size());
 
@@ -478,12 +482,11 @@ fn ui(f: &mut Frame, app_state: &mut AppState, args: &InteractiveArgs, ls_colors
         "Press / to search, q to quit".to_string()
     };
 
-    let status_paragraph = Paragraph::new(status_text)
-        .style(if app_state.in_search_mode() { 
-            Style::default().fg(Color::Yellow) 
-        } else { 
-            Style::default().fg(Color::Gray) 
-        });
+    let status_paragraph = Paragraph::new(status_text).style(if app_state.in_search_mode() {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::Gray)
+    });
     f.render_widget(status_paragraph, chunks[1]);
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,6 +11,7 @@ use crate::utils;
 use ignore::WalkBuilder;
 use lscolors::{Color as LsColor, LsColors, Style as LsStyle};
 use ratatui::crossterm::{
+    cursor,
     event::{
         self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
     },
@@ -305,9 +306,10 @@ pub fn run(args: &InteractiveArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     let root_path = fs::canonicalize(&args.path)?;
 
     let mut app_state = AppState::new(args, &root_path)?;
-    let mut terminal = setup_terminal()?;
-    let post_exit_action = run_app(&mut terminal, &mut app_state, args, ls_colors)?;
-    restore_terminal(&mut terminal)?;
+    let (mut terminal, guard) = setup_terminal()?;
+    let run_result = run_app(&mut terminal, &mut app_state, args, ls_colors);
+    drop(guard);
+    let post_exit_action = run_result?;
 
     match post_exit_action {
         PostExitAction::OpenFile(path) => {
@@ -570,21 +572,51 @@ fn map_color(c: colored::Color) -> Color {
 
 type TerminalWriter = CrosstermBackend<Box<dyn Write + Send>>;
 
-fn setup_terminal() -> anyhow::Result<Terminal<TerminalWriter>> {
+/// Restores the terminal to its normal state (cooked mode, main screen, visible
+/// cursor). Best-effort and idempotent so it is safe from both the drop guard
+/// and the panic hook.
+fn restore_terminal_state(use_stderr: bool) {
+    let _ = disable_raw_mode();
+    if use_stderr {
+        let _ = execute!(stderr(), LeaveAlternateScreen, DisableMouseCapture, cursor::Show);
+    } else {
+        let _ = execute!(stdout(), LeaveAlternateScreen, DisableMouseCapture, cursor::Show);
+    }
+}
+
+/// Restores the terminal when dropped, covering `?` early returns from the
+/// event loop. Panics are handled separately by the hook installed in
+/// `setup_terminal`, since the release profile uses `panic = "abort"` and
+/// never unwinds into destructors.
+struct TerminalGuard {
+    use_stderr: bool,
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        restore_terminal_state(self.use_stderr);
+    }
+}
+
+fn setup_terminal() -> anyhow::Result<(Terminal<TerminalWriter>, TerminalGuard)> {
+    let use_stderr = !stdout().is_terminal();
     let writer: Box<dyn Write + Send> =
-        if stdout().is_terminal() { Box::new(stdout()) } else { Box::new(stderr()) };
+        if use_stderr { Box::new(stderr()) } else { Box::new(stdout()) };
+
+    // Restore the terminal before the default panic handler prints, so the
+    // message is readable and the user's shell is not left in raw mode.
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_terminal_state(use_stderr);
+        default_hook(info);
+    }));
+
     enable_raw_mode()?;
+    let guard = TerminalGuard { use_stderr };
     let mut writer_mut = writer;
     execute!(writer_mut, EnterAlternateScreen, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(writer_mut);
-    Terminal::new(backend).map_err(anyhow::Error::from)
-}
-
-fn restore_terminal<B: Backend + Write>(terminal: &mut Terminal<B>) -> anyhow::Result<()> {
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
-    terminal.show_cursor()?;
-    Ok(())
+    Ok((Terminal::new(backend)?, guard))
 }
 
 #[cfg(test)]

--- a/src/view.rs
+++ b/src/view.rs
@@ -31,12 +31,9 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     }
 
     // Format root directory with same alignment as tree entries
-    let root_metadata = if args.size || args.permissions { 
-        fs::metadata(&args.path).ok() 
-    } else { 
-        None 
-    };
-    
+    let root_metadata =
+        if args.size || args.permissions { fs::metadata(&args.path).ok() } else { None };
+
     let root_permissions_str = if args.permissions {
         let perms = if let Some(md) = &root_metadata {
             #[cfg(unix)]
@@ -57,20 +54,22 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     } else {
         String::new()
     };
-    
+
     let root_git_status_str = if args.git_status {
         "  ".to_string() // Empty git status column for consistent spacing
     } else {
         String::new()
     };
-    
+
     if writeln!(
-        io::stdout(), 
+        io::stdout(),
         "{}{}{}",
         root_git_status_str,
-        root_permissions_str, 
+        root_permissions_str,
         args.path.display().to_string().blue().bold()
-    ).is_err() {
+    )
+    .is_err()
+    {
         return Ok(());
     }
 
@@ -274,7 +273,6 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
 
     Ok(())
 }
-
 
 /// Builds tree structure information for proper connector display
 /// Returns a map from entry index to (prefix, connector) tuple  


### PR DESCRIPTION
## Summary

Three hardening fixes for the interactive TUI plus unbreaking the CI gates on `main`:

- **CI gates**: derive `Default` on `sort::SortType` (clippy `derivable_impls` failed under `-D warnings`) and apply `cargo fmt` (trailing whitespace in `sort.rs`, `tui.rs`, `view.rs`).
- **Terminal restore**: a drop guard now restores the terminal on `?` early returns from the event loop (previously `run()` propagated errors before `restore_terminal` ran), and a panic hook restores it before the panic message prints — required for release builds where `panic = "abort"` never unwinds into destructors.
- **TUI search fixes**:
  - Typing `q`/`j`/`k` in a search query no longer triggers command keys (searching for "query" used to quit the app)
  - Search accepts any printable character instead of a small whitelist (`+`, `#`, `(` now work)
  - Navigating an empty directory or empty search results no longer panics with a usize underflow
  - Enter on a directory during search exits search mode before toggling instead of corrupting the saved entry list
  - Exiting search re-selects the highlighted entry by path instead of reusing a stale index
  - Key handling extracted into `handle_key()` for unit testability

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass (27 unit + 19 CLI tests; 9 new unit tests pin the search/navigation fixes)
- `./scripts/validate-basic.sh` — all baseline outputs match
- Verified end-to-end under `expect` on a real pty: the empty-directory panic reproduced on the old code and the panic hook restored the terminal; on the fixed code the same key sequence exits cleanly, and typing `sq` in search mode leaves the app running with the tty restored on exit