### PR TITLE
Tie all standard ignore filters to the -g flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed ignore files (`.ignore`, global gitignore, `.git/info/exclude`) filtering output even without the `-g` flag; all standard ignore filters are now tied to `-g` in both classic and interactive modes
 - Fixed the interactive TUI quitting when typing `q` (or other command keys) into a search query
 - Fixed a crash when navigating an empty directory or empty search results in interactive mode
 - Fixed the terminal being left in raw mode on the alternate screen when the TUI exited with an error or panic

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -529,7 +529,7 @@ fn scan_directory(
     args: &InteractiveArgs,
 ) -> anyhow::Result<Vec<FileEntry>> {
     let mut builder = WalkBuilder::new(path);
-    builder.hidden(!args.all).git_ignore(args.gitignore);
+    utils::configure_ignore_filters(&mut builder, args.all, args.gitignore);
 
     // Collect all DirEntry objects first, filtering out the root path
     let mut dir_entries: Vec<_> =

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,22 @@
 //! Shared utility functions for the lstr application.
 
-// This entire module will only be compiled on Unix-like systems.
+/// Configures a directory walker's filtering to match the CLI contract:
+/// hidden files are shown only with `-a`, and `.gitignore` plus the other
+/// standard ignore files (`.ignore`, global gitignore, `.git/info/exclude`,
+/// ignore files in parent directories) apply only with `-g`.
+///
+/// `WalkBuilder` enables all of these filters by default, so each one must
+/// be tied to the flags explicitly.
+pub fn configure_ignore_filters(builder: &mut ignore::WalkBuilder, all: bool, gitignore: bool) {
+    builder
+        .standard_filters(false)
+        .hidden(!all)
+        .parents(gitignore)
+        .ignore(gitignore)
+        .git_ignore(gitignore)
+        .git_global(gitignore)
+        .git_exclude(gitignore);
+}
 
 /// Formats a size in bytes into a human-readable string using binary prefixes (KiB, MiB).
 pub fn format_size(bytes: u64) -> String {

--- a/src/view.rs
+++ b/src/view.rs
@@ -78,7 +78,7 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     let repo_root = git_repo_status.as_ref().map(|s| &s.root);
 
     let mut builder = WalkBuilder::new(&args.path);
-    builder.hidden(!args.all).git_ignore(args.gitignore);
+    utils::configure_ignore_filters(&mut builder, args.all, args.gitignore);
     if let Some(level) = args.level {
         builder.max_depth(Some(level));
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -500,3 +500,29 @@ fn test_deep_nested_tree() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_ignore_files_only_respected_with_gitignore_flag() -> Result<(), Box<dyn std::error::Error>>
+{
+    let temp_dir = tempdir()?;
+    fs::write(temp_dir.path().join(".ignore"), "secret.txt\n")?;
+    fs::File::create(temp_dir.path().join("secret.txt"))?;
+    fs::File::create(temp_dir.path().join("visible.txt"))?;
+
+    // Without -g, ignore files must not filter the output.
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg(temp_dir.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("secret.txt"))
+        .stdout(predicate::str::contains("visible.txt"));
+
+    // With -g, .ignore files are respected like .gitignore.
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("-g").arg(temp_dir.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("visible.txt"))
+        .stdout(predicate::str::contains("secret.txt").not());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`WalkBuilder` enables `.ignore` files, the user's global gitignore, and `.git/info/exclude` by default — the code only toggled `hidden` and `git_ignore`. So plain `lstr` (no flags) silently hid files matched by a `.ignore` file or the user's global gitignore, contradicting the `-g` flag's contract ("Respect .gitignore and other standard ignore files").

All standard filters are now configured explicitly via a shared `utils::configure_ignore_filters()` used by both the classic view and the TUI, so the two modes cannot drift:

- without `-g`: only the hidden-file filter applies (controlled by `-a`)
- with `-g`: `.gitignore`, `.ignore`, global gitignore, `.git/info/exclude`, and parent-directory ignore files all apply

## Testing

- New CLI test `test_ignore_files_only_respected_with_gitignore_flag` (written first, red on the old code) pins both directions
- Existing `test_gitignore_flag` (real git repo) still passes; full suite green (27 unit + 20 CLI), fmt/clippy clean, all baseline outputs match
- Verified manually: a file listed in `.ignore` now appears without `-g` and is hidden with `-g`

**Stacked on #43** — will retarget to `main` when that merges.