### PR TITLE
Deduplicate shared CLI args and unify SortType

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -28,66 +28,10 @@ pub enum Commands {
     Interactive(InteractiveArgs),
 }
 
-/// Arguments for the classic `view` command.
+/// Arguments shared by the classic tree view and the interactive TUI.
 #[derive(Parser, Debug, Default)]
-pub struct ViewArgs {
+pub struct CommonArgs {
     /// The path to the directory to display. Defaults to the current directory.
-    #[arg(default_value = ".")]
-    pub path: PathBuf,
-    /// Specify when to use colorized output.
-    #[arg(long, value_name = "WHEN", default_value_t = ColorChoice::Auto)]
-    pub color: ColorChoice,
-    /// Maximum depth to descend in the directory tree.
-    #[arg(short = 'L', long)]
-    pub level: Option<usize>,
-    /// Display directories only.
-    #[arg(short = 'd', long)]
-    pub dirs_only: bool,
-    /// Display the size of files.
-    #[arg(short = 's', long)]
-    pub size: bool,
-    /// Display file permissions.
-    #[arg(short = 'p', long)]
-    pub permissions: bool,
-    /// Show all files, including hidden ones.
-    #[arg(short = 'a', long, help = "Show all files, including hidden ones")]
-    pub all: bool,
-    /// Respect .gitignore and other standard ignore files.
-    #[arg(short = 'g', long)]
-    pub gitignore: bool,
-    /// Show git status for files and directories.
-    #[arg(short = 'G', long)]
-    pub git_status: bool,
-    /// Display file-specific icons (requires a Nerd Font).
-    #[arg(long, help = "Display file-specific icons (requires a Nerd Font)")]
-    pub icons: bool,
-    /// Render file paths as clickable hyperlinks.
-    #[arg(long)]
-    pub hyperlinks: bool,
-    /// Sort entries by the specified criteria.
-    #[arg(long, default_value_t = SortType::Name)]
-    pub sort: SortType,
-    /// Sort directories before files.
-    #[arg(long)]
-    pub dirs_first: bool,
-    /// Use case-sensitive sorting.
-    #[arg(long)]
-    pub case_sensitive: bool,
-    /// Use natural/version sorting (e.g., file1 < file10).
-    #[arg(long)]
-    pub natural_sort: bool,
-    /// Reverse the sort order.
-    #[arg(short = 'r', long)]
-    pub reverse: bool,
-    /// Sort dotfiles and dotfolders first.
-    #[arg(long)]
-    pub dotfiles_first: bool,
-}
-
-/// Arguments for the `interactive` command.
-#[derive(Parser, Debug)]
-pub struct InteractiveArgs {
-    /// The path to the directory to explore. Defaults to the current directory.
     #[arg(default_value = ".")]
     pub path: PathBuf,
     /// Show all files, including hidden ones.
@@ -108,12 +52,9 @@ pub struct InteractiveArgs {
     /// Display file permissions.
     #[arg(short = 'p', long)]
     pub permissions: bool,
-    /// Initial depth to expand the directory tree.
-    #[arg(long, value_name = "LEVEL")]
-    pub expand_level: Option<usize>,
     /// Sort entries by the specified criteria.
-    #[arg(long, default_value_t = SortType::Name)]
-    pub sort: SortType,
+    #[arg(long, default_value_t = sort::SortType::Name)]
+    pub sort: sort::SortType,
     /// Sort directories before files.
     #[arg(long)]
     pub dirs_first: bool,
@@ -131,18 +72,49 @@ pub struct InteractiveArgs {
     pub dotfiles_first: bool,
 }
 
-/// Defines the available sorting strategies.
-#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq, Default)]
-pub enum SortType {
-    /// Sort by name (default)
-    #[default]
-    Name,
-    /// Sort by file size
-    Size,
-    /// Sort by modification time
-    Modified,
-    /// Sort by file extension
-    Extension,
+impl CommonArgs {
+    /// Creates a SortOptions instance from the shared sorting flags.
+    pub fn to_sort_options(&self) -> sort::SortOptions {
+        sort::SortOptions {
+            sort_type: self.sort,
+            directories_first: self.dirs_first,
+            case_sensitive: self.case_sensitive,
+            natural_sort: self.natural_sort,
+            reverse: self.reverse,
+            dotfiles_first: self.dotfiles_first,
+        }
+    }
+}
+
+/// Arguments for the classic `view` command.
+#[derive(Parser, Debug, Default)]
+pub struct ViewArgs {
+    /// The arguments shared with the interactive TUI.
+    #[command(flatten)]
+    pub common: CommonArgs,
+    /// Specify when to use colorized output.
+    #[arg(long, value_name = "WHEN", default_value_t = ColorChoice::Auto)]
+    pub color: ColorChoice,
+    /// Maximum depth to descend in the directory tree.
+    #[arg(short = 'L', long)]
+    pub level: Option<usize>,
+    /// Display directories only.
+    #[arg(short = 'd', long)]
+    pub dirs_only: bool,
+    /// Render file paths as clickable hyperlinks.
+    #[arg(long)]
+    pub hyperlinks: bool,
+}
+
+/// Arguments for the `interactive` command.
+#[derive(Parser, Debug, Default)]
+pub struct InteractiveArgs {
+    /// The arguments shared with the classic tree view.
+    #[command(flatten)]
+    pub common: CommonArgs,
+    /// Initial depth to expand the directory tree.
+    #[arg(long, value_name = "LEVEL")]
+    pub expand_level: Option<usize>,
 }
 
 /// Defines the choices for the --color option.
@@ -152,52 +124,6 @@ pub enum ColorChoice {
     #[default]
     Auto,
     Never,
-}
-
-impl From<SortType> for sort::SortType {
-    fn from(sort_type: SortType) -> Self {
-        match sort_type {
-            SortType::Name => sort::SortType::Name,
-            SortType::Size => sort::SortType::Size,
-            SortType::Modified => sort::SortType::Modified,
-            SortType::Extension => sort::SortType::Extension,
-        }
-    }
-}
-
-impl ViewArgs {
-    /// Creates a SortOptions instance from the ViewArgs.
-    pub fn to_sort_options(&self) -> sort::SortOptions {
-        sort::SortOptions {
-            sort_type: self.sort.into(),
-            directories_first: self.dirs_first,
-            case_sensitive: self.case_sensitive,
-            natural_sort: self.natural_sort,
-            reverse: self.reverse,
-            dotfiles_first: self.dotfiles_first,
-        }
-    }
-}
-
-impl InteractiveArgs {
-    /// Creates a SortOptions instance from the InteractiveArgs.
-    pub fn to_sort_options(&self) -> sort::SortOptions {
-        sort::SortOptions {
-            sort_type: self.sort.into(),
-            directories_first: self.dirs_first,
-            case_sensitive: self.case_sensitive,
-            natural_sort: self.natural_sort,
-            reverse: self.reverse,
-            dotfiles_first: self.dotfiles_first,
-        }
-    }
-}
-
-/// Implements the Display trait for SortType to show possible values in help messages.
-impl fmt::Display for SortType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.to_possible_value().expect("no values are skipped").get_name().fmt(f)
-    }
 }
 
 /// Implements the Display trait for ColorChoice to show possible values in help messages.

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -3,12 +3,14 @@
 //! This module implements various sorting strategies for file and directory entries,
 //! ensuring consistent behavior across all supported platforms (Windows, macOS, Linux).
 
+use clap::ValueEnum;
 use ignore::DirEntry;
 use std::cmp::Ordering;
 use std::ffi::OsStr;
+use std::fmt;
 
 /// Defines the available sorting strategies.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
 pub enum SortType {
     /// Sort by name (default)
     #[default]
@@ -19,6 +21,13 @@ pub enum SortType {
     Modified,
     /// Sort by file extension
     Extension,
+}
+
+/// Implements the Display trait for SortType to show possible values in help messages.
+impl fmt::Display for SortType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.to_possible_value().expect("no values are skipped").get_name().fmt(f)
+    }
 }
 
 /// Configuration options for sorting directory entries.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -117,7 +117,8 @@ struct AppState {
 
 impl AppState {
     fn new(args: &InteractiveArgs, root_path: &Path) -> anyhow::Result<Self> {
-        let git_repo_status = if args.git_status { git::load_status(root_path)? } else { None };
+        let git_repo_status =
+            if args.common.git_status { git::load_status(root_path)? } else { None };
 
         let status_info = git_repo_status.as_ref().map(|s| (&s.cache, &s.root));
         let mut master_entries = scan_directory(root_path, status_info, args)?;
@@ -319,10 +320,10 @@ impl AppState {
 }
 
 pub fn run(args: &InteractiveArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
-    if !args.path.is_dir() {
-        anyhow::bail!("'{}' is not a directory.", args.path.display());
+    if !args.common.path.is_dir() {
+        anyhow::bail!("'{}' is not a directory.", args.common.path.display());
     }
-    let root_path = fs::canonicalize(&args.path)?;
+    let root_path = fs::canonicalize(&args.common.path)?;
 
     let mut app_state = AppState::new(args, &root_path)?;
     let (mut terminal, guard) = setup_terminal()?;
@@ -430,7 +431,7 @@ fn ui(f: &mut Frame, app_state: &mut AppState, args: &InteractiveArgs, ls_colors
         .iter()
         .map(|entry| {
             let mut spans = Vec::new();
-            if args.git_status {
+            if args.common.git_status {
                 let (status_char, status_color) = if let Some(status) = entry.git_status {
                     let color = match status {
                         git::FileStatus::New | git::FileStatus::Renamed => Color::Green,
@@ -448,7 +449,7 @@ fn ui(f: &mut Frame, app_state: &mut AppState, args: &InteractiveArgs, ls_colors
                     Style::default().fg(status_color),
                 ));
             }
-            if args.permissions {
+            if args.common.permissions {
                 let perms_str = entry.permissions.as_deref().unwrap_or("----------");
                 spans.push(Span::styled(
                     format!("{perms_str} "),
@@ -467,7 +468,7 @@ fn ui(f: &mut Frame, app_state: &mut AppState, args: &InteractiveArgs, ls_colors
                 "  "
             };
             spans.push(Span::raw(branch_str));
-            if args.icons {
+            if args.common.icons {
                 let (icon, color) = icons::get_icon_for_path(&entry.path, entry.is_dir);
                 spans.push(Span::styled(format!("{icon} "), Style::default().fg(map_color(color))));
             }
@@ -478,7 +479,7 @@ fn ui(f: &mut Frame, app_state: &mut AppState, args: &InteractiveArgs, ls_colors
             let name_span = Span::styled(name.to_string(), ratatui_style);
             spans.push(name_span);
 
-            if args.size && !entry.is_dir {
+            if args.common.size && !entry.is_dir {
                 if let Some(size) = entry.size {
                     let size_str = utils::format_size(size);
                     let left_len: usize = spans.iter().map(|s| s.width()).sum();
@@ -529,28 +530,30 @@ fn scan_directory(
     args: &InteractiveArgs,
 ) -> anyhow::Result<Vec<FileEntry>> {
     let mut builder = WalkBuilder::new(path);
-    utils::configure_ignore_filters(&mut builder, args.all, args.gitignore);
+    utils::configure_ignore_filters(&mut builder, args.common.all, args.common.gitignore);
 
     // Collect all DirEntry objects first, filtering out the root path
     let mut dir_entries: Vec<_> =
         builder.build().flatten().filter(|result| result.path() != path).collect();
 
     // Apply tree-aware sorting to preserve parent-child relationships
-    let sort_options = args.to_sort_options();
+    let sort_options = args.common.to_sort_options();
     sort::sort_entries_hierarchically(&mut dir_entries, &sort_options);
 
     // Convert DirEntry objects to FileEntry objects
     let mut entries = Vec::new();
     for result in dir_entries {
-        let metadata = if args.size || args.permissions { result.metadata().ok() } else { None };
+        let metadata =
+            if args.common.size || args.common.permissions { result.metadata().ok() } else { None };
         let is_dir = result.file_type().is_some_and(|ft| ft.is_dir());
         let git_status = if let Some((cache, root)) = status_info {
             result.path().strip_prefix(root).ok().and_then(|rel_path| cache.get(rel_path)).copied()
         } else {
             None
         };
-        let size = if args.size && !is_dir { metadata.as_ref().map(|m| m.len()) } else { None };
-        let permissions = if args.permissions {
+        let size =
+            if args.common.size && !is_dir { metadata.as_ref().map(|m| m.len()) } else { None };
+        let permissions = if args.common.permissions {
             metadata.map(|_md| {
                 #[cfg(unix)]
                 {

--- a/src/view.rs
+++ b/src/view.rs
@@ -18,11 +18,11 @@ use std::os::unix::fs::PermissionsExt;
 
 /// Executes the classic directory tree view
 pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
-    if !args.path.is_dir() {
-        anyhow::bail!("'{}' is not a directory.", args.path.display());
+    if !args.common.path.is_dir() {
+        anyhow::bail!("'{}' is not a directory.", args.common.path.display());
     }
 
-    let canonical_root = fs::canonicalize(&args.path)?;
+    let canonical_root = fs::canonicalize(&args.common.path)?;
 
     match args.color {
         crate::app::ColorChoice::Always => control::set_override(true),
@@ -31,10 +31,13 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     }
 
     // Format root directory with same alignment as tree entries
-    let root_metadata =
-        if args.size || args.permissions { fs::metadata(&args.path).ok() } else { None };
+    let root_metadata = if args.common.size || args.common.permissions {
+        fs::metadata(&args.common.path).ok()
+    } else {
+        None
+    };
 
-    let root_permissions_str = if args.permissions {
+    let root_permissions_str = if args.common.permissions {
         let perms = if let Some(md) = &root_metadata {
             #[cfg(unix)]
             {
@@ -55,7 +58,7 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         String::new()
     };
 
-    let root_git_status_str = if args.git_status {
+    let root_git_status_str = if args.common.git_status {
         "  ".to_string() // Empty git status column for consistent spacing
     } else {
         String::new()
@@ -66,19 +69,20 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         "{}{}{}",
         root_git_status_str,
         root_permissions_str,
-        args.path.display().to_string().blue().bold()
+        args.common.path.display().to_string().blue().bold()
     )
     .is_err()
     {
         return Ok(());
     }
 
-    let git_repo_status = if args.git_status { git::load_status(&canonical_root)? } else { None };
+    let git_repo_status =
+        if args.common.git_status { git::load_status(&canonical_root)? } else { None };
     let status_cache = git_repo_status.as_ref().map(|s| &s.cache);
     let repo_root = git_repo_status.as_ref().map(|s| &s.root);
 
-    let mut builder = WalkBuilder::new(&args.path);
-    utils::configure_ignore_filters(&mut builder, args.all, args.gitignore);
+    let mut builder = WalkBuilder::new(&args.common.path);
+    utils::configure_ignore_filters(&mut builder, args.common.all, args.common.gitignore);
     if let Some(level) = args.level {
         builder.max_depth(Some(level));
     }
@@ -111,7 +115,7 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     }
 
     // Apply tree-aware sorting (preserves parent-child relationships)
-    let sort_options = args.to_sort_options();
+    let sort_options = args.common.to_sort_options();
     sort::sort_entries_hierarchically(&mut entries, &sort_options);
 
     // Build tree structure information
@@ -151,8 +155,9 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
             String::new()
         };
 
-        let metadata = if args.size || args.permissions { entry.metadata().ok() } else { None };
-        let permissions_str = if args.permissions {
+        let metadata =
+            if args.common.size || args.common.permissions { entry.metadata().ok() } else { None };
+        let permissions_str = if args.common.permissions {
             let perms = if let Some(md) = &metadata {
                 // <-- Use 'md' here
                 #[cfg(unix)]
@@ -178,13 +183,13 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
 
         let (prefix, connector) = &tree_info[index];
         let name = entry.file_name().to_string_lossy();
-        let icon_str = if args.icons {
+        let icon_str = if args.common.icons {
             let (icon, color) = icons::get_icon_for_path(entry.path(), is_dir);
             format!("{} ", icon.color(color))
         } else {
             String::new()
         };
-        let size_str = if args.size && !is_dir {
+        let size_str = if args.common.size && !is_dir {
             metadata
                 .as_ref()
                 .map(|m| format!(" ({})", utils::format_size(m.len())))


### PR DESCRIPTION
## Summary

Structural cleanup so every future flag is declared once instead of twice:

- **`CommonArgs`**: `ViewArgs` and `InteractiveArgs` duplicated ~13 fields (path, display flags, all six sorting flags) plus verbatim-identical `to_sort_options()` methods. The shared fields now live in a single `CommonArgs` struct `#[command(flatten)]`-ed into both; `to_sort_options()` exists once.
- **Single `SortType`**: `app::SortType` existed only to derive `ValueEnum` and mirror `sort::SortType` through a `From` bridge. `ValueEnum` and the `Display` impl now live on `sort::SortType` directly; the duplicate enum and conversion are deleted.

Net: −57 lines, `app.rs` shrinks from 208 to 137 lines.

## Compatibility

No user-facing change intended. Verified by diffing the full flag surface of `lstr --help` and `lstr interactive --help` before/after — **byte-identical** for both subcommands (same short/long names, same value names for `--sort`).

## Testing

Full suite green (27 unit + 21 CLI), fmt/clippy clean, all `docs/baseline-outputs/` golden files match.