### PR TITLE
Polish batch: permissions, hyperlinks, mouse capture, dir git status, Windows paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Status line shows current search query and match count
   - Preserves tree structure and selection state during filtering ([Closes #30](https://github.com/bgreenwell/lstr/issues/30))
 
+### Added
+
+- Directories now show the most severe git status of their contents with `-G`, in both classic and interactive modes
+
 ### Changed
 
+- File permissions now display `l` for symlinks and the setuid/setgid/sticky special bits (`s`/`S`, `t`/`T`)
 - Improved sorting performance: metadata lookups and string allocations now happen once per entry instead of once per comparison (`--sort modified` on a 40k-entry tree: ~2.6× faster)
 - Improved `-G` git-status performance in classic mode by removing a filesystem canonicalization syscall per entry (~2× faster on a 10k-file repository)
 
 ### Fixed
 
+- Fixed hyperlink escape sequences being emitted under `--color never` and into pipes; hyperlinks now follow the colorization decision
+- Fixed the TUI capturing mouse events it never handled, which broke click-drag text selection in the terminal
+- Fixed interactive mode printing Windows `\\?\` verbatim paths from Ctrl+s ([Closes #24](https://github.com/bgreenwell/lstr/issues/24))
 - Fixed wrong tree connectors with `--dirs-only`, where a directory could render `├──` because filtered-out files after it were counted as siblings
 - Fixed quadratic tree-connector computation that made large directory trees (tens of thousands of entries) take seconds instead of milliseconds
 - Fixed ignore files (`.ignore`, global gitignore, `.git/info/exclude`) filtering output even without the `-g` flag; all standard ignore filters are now tied to `-g` in both classic and interactive modes

--- a/src/git.rs
+++ b/src/git.rs
@@ -32,6 +32,21 @@ impl FileStatus {
             Self::Conflicted => 'C',
         }
     }
+
+    /// Relative severity used when propagating statuses to parent
+    /// directories; the higher value wins when a directory contains
+    /// files with different statuses.
+    fn severity(self) -> u8 {
+        match self {
+            Self::Conflicted => 6,
+            Self::Deleted => 5,
+            Self::Modified => 4,
+            Self::Typechange => 3,
+            Self::Renamed => 2,
+            Self::New => 1,
+            Self::Untracked => 0,
+        }
+    }
 }
 
 /// A cache mapping file paths to their Git status.
@@ -72,6 +87,29 @@ pub fn load_status(start_path: &Path) -> anyhow::Result<Option<GitRepoStatus>> {
         if let Some(path_str) = entry.path() {
             // Use the relative path directly as the key.
             cache.insert(PathBuf::from(path_str), status);
+        }
+    }
+
+    // Propagate each file's status to its ancestor directories so that
+    // folders containing changes get a marker too, with the most severe
+    // status winning.
+    let file_statuses: Vec<(PathBuf, FileStatus)> =
+        cache.iter().map(|(path, status)| (path.clone(), *status)).collect();
+    for (path, status) in file_statuses {
+        let mut ancestor = path.parent();
+        while let Some(dir) = ancestor {
+            if dir.as_os_str().is_empty() {
+                break;
+            }
+            cache
+                .entry(dir.to_path_buf())
+                .and_modify(|existing| {
+                    if status.severity() > existing.severity() {
+                        *existing = status;
+                    }
+                })
+                .or_insert(status);
+            ancestor = dir.parent();
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -33,10 +33,6 @@ use std::io::{stderr, stdout, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-// Platform-specific import for unix permissions
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
 /// Converts an lscolors::Style to a ratatui::style::Style
 fn to_ratatui_style(ls_style: LsStyle) -> Style {
     let mut style = Style::default();
@@ -554,18 +550,7 @@ fn scan_directory(
         let size =
             if args.common.size && !is_dir { metadata.as_ref().map(|m| m.len()) } else { None };
         let permissions = if args.common.permissions {
-            metadata.map(|_md| {
-                #[cfg(unix)]
-                {
-                    let mode = _md.permissions().mode();
-                    let file_type_char = if _md.is_dir() { 'd' } else { '-' };
-                    format!("{}{}", file_type_char, utils::format_permissions(mode))
-                }
-                #[cfg(not(unix))]
-                {
-                    "----------".to_string()
-                }
-            })
+            metadata.as_ref().map(utils::permission_string)
         } else {
             None
         };

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -13,8 +13,7 @@ use lscolors::{Color as LsColor, LsColors, Style as LsStyle};
 use ratatui::crossterm::{
     cursor,
     event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
-        KeyModifiers,
+        self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
     },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -597,9 +596,9 @@ type TerminalWriter = CrosstermBackend<Box<dyn Write + Send>>;
 fn restore_terminal_state(use_stderr: bool) {
     let _ = disable_raw_mode();
     if use_stderr {
-        let _ = execute!(stderr(), LeaveAlternateScreen, DisableMouseCapture, cursor::Show);
+        let _ = execute!(stderr(), LeaveAlternateScreen, cursor::Show);
     } else {
-        let _ = execute!(stdout(), LeaveAlternateScreen, DisableMouseCapture, cursor::Show);
+        let _ = execute!(stdout(), LeaveAlternateScreen, cursor::Show);
     }
 }
 
@@ -633,7 +632,7 @@ fn setup_terminal() -> anyhow::Result<(Terminal<TerminalWriter>, TerminalGuard)>
     enable_raw_mode()?;
     let guard = TerminalGuard { use_stderr };
     let mut writer_mut = writer;
-    execute!(writer_mut, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(writer_mut, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(writer_mut);
     Ok((Terminal::new(backend)?, guard))
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -12,9 +12,7 @@ use ignore::WalkBuilder;
 use lscolors::{Color as LsColor, LsColors, Style as LsStyle};
 use ratatui::crossterm::{
     cursor,
-    event::{
-        self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
-    },
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -335,10 +333,10 @@ pub fn run(args: &InteractiveArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
                     "vim".to_string()
                 }
             });
-            Command::new(editor).arg(path).status()?;
+            Command::new(editor).arg(utils::display_path(&path)).status()?;
         }
         PostExitAction::PrintPath(path) => {
-            println!("{}", path.display());
+            println!("{}", utils::display_path(&path).display());
         }
         PostExitAction::None => {}
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,6 +18,45 @@ pub fn configure_ignore_filters(builder: &mut ignore::WalkBuilder, all: bool, gi
         .git_exclude(gitignore);
 }
 
+/// Returns a copy of `path` suitable for display, converting Windows
+/// verbatim paths (`\\?\C:\...` and `\\?\UNC\server\share\...`) produced by
+/// `fs::canonicalize` back to their conventional form. On other platforms
+/// the path is returned unchanged.
+pub fn display_path(path: &std::path::Path) -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        use std::ffi::OsString;
+        use std::path::{Component, Prefix};
+
+        let mut components = path.components();
+        let Some(Component::Prefix(prefix)) = components.next() else {
+            return path.to_path_buf();
+        };
+        let root = match prefix.kind() {
+            Prefix::VerbatimDisk(disk) => std::path::PathBuf::from(format!(r"{}:\", disk as char)),
+            Prefix::VerbatimUNC(server, share) => {
+                let mut s = OsString::from(r"\\");
+                s.push(server);
+                s.push(r"\");
+                s.push(share);
+                std::path::PathBuf::from(s)
+            }
+            _ => return path.to_path_buf(),
+        };
+        let mut result = root;
+        for component in components {
+            if component != Component::RootDir {
+                result.push(component.as_os_str());
+            }
+        }
+        result
+    }
+    #[cfg(not(windows))]
+    {
+        path.to_path_buf()
+    }
+}
+
 /// Formats a size in bytes into a human-readable string using binary prefixes (KiB, MiB).
 pub fn format_size(bytes: u64) -> String {
     const KIB: f64 = 1024.0;
@@ -124,6 +163,30 @@ mod tests {
         // -rwx------
         let mode_user_only = 0o700;
         assert_eq!(format_permissions(mode_user_only), "rwx------");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_display_path_strips_verbatim_prefix() {
+        use std::path::Path;
+        assert_eq!(
+            display_path(Path::new(r"\\?\C:\Users\test\file.txt")),
+            Path::new(r"C:\Users\test\file.txt")
+        );
+        assert_eq!(
+            display_path(Path::new(r"\\?\UNC\server\share\dir")),
+            Path::new(r"\\server\share\dir")
+        );
+        // Conventional and relative paths pass through unchanged.
+        assert_eq!(display_path(Path::new(r"C:\normal\path")), Path::new(r"C:\normal\path"));
+        assert_eq!(display_path(Path::new(r"relative\path")), Path::new(r"relative\path"));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_display_path_is_identity_on_non_windows() {
+        use std::path::Path;
+        assert_eq!(display_path(Path::new("/usr/local/bin")), Path::new("/usr/local/bin"));
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,18 +40,58 @@ pub fn format_size(bytes: u64) -> String {
     }
 }
 
-/// Formats a Unix file mode into a human-readable string (e.g., "rwxr-xr-x").
+/// Formats a file's metadata as an `ls -l`-style permission string,
+/// including the file-type character (`d`, `l`, or `-`).
+///
+/// On non-Unix platforms this returns a `"----------"` placeholder.
+pub fn permission_string(metadata: &std::fs::Metadata) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let type_char = if metadata.file_type().is_symlink() {
+            'l'
+        } else if metadata.is_dir() {
+            'd'
+        } else {
+            '-'
+        };
+        format!("{}{}", type_char, format_permissions(metadata.permissions().mode()))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        "----------".to_string()
+    }
+}
+
+/// Formats a Unix file mode into a human-readable string (e.g., "rwxr-xr-x"),
+/// including the setuid (`s`/`S`), setgid (`s`/`S`), and sticky (`t`/`T`) bits.
 #[cfg(unix)]
 pub fn format_permissions(mode: u32) -> String {
     let user_r = if mode & 0o400 != 0 { 'r' } else { '-' };
     let user_w = if mode & 0o200 != 0 { 'w' } else { '-' };
-    let user_x = if mode & 0o100 != 0 { 'x' } else { '-' };
+    let user_x = match (mode & 0o100 != 0, mode & 0o4000 != 0) {
+        (true, true) => 's',
+        (false, true) => 'S',
+        (true, false) => 'x',
+        (false, false) => '-',
+    };
     let group_r = if mode & 0o040 != 0 { 'r' } else { '-' };
     let group_w = if mode & 0o020 != 0 { 'w' } else { '-' };
-    let group_x = if mode & 0o010 != 0 { 'x' } else { '-' };
+    let group_x = match (mode & 0o010 != 0, mode & 0o2000 != 0) {
+        (true, true) => 's',
+        (false, true) => 'S',
+        (true, false) => 'x',
+        (false, false) => '-',
+    };
     let other_r = if mode & 0o004 != 0 { 'r' } else { '-' };
     let other_w = if mode & 0o002 != 0 { 'w' } else { '-' };
-    let other_x = if mode & 0o001 != 0 { 'x' } else { '-' };
+    let other_x = match (mode & 0o001 != 0, mode & 0o1000 != 0) {
+        (true, true) => 't',
+        (false, true) => 'T',
+        (true, false) => 'x',
+        (false, false) => '-',
+    };
     format!("{user_r}{user_w}{user_x}{group_r}{group_w}{group_x}{other_r}{other_w}{other_x}")
 }
 
@@ -84,5 +124,20 @@ mod tests {
         // -rwx------
         let mode_user_only = 0o700;
         assert_eq!(format_permissions(mode_user_only), "rwx------");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_format_permissions_special_bits() {
+        // setuid with execute (e.g. /usr/bin/sudo)
+        assert_eq!(format_permissions(0o4755), "rwsr-xr-x");
+        // setuid without execute
+        assert_eq!(format_permissions(0o4655), "rwSr-xr-x");
+        // setgid with execute
+        assert_eq!(format_permissions(0o2755), "rwxr-sr-x");
+        // sticky bit with execute (e.g. /tmp)
+        assert_eq!(format_permissions(0o1777), "rwxrwxrwt");
+        // sticky bit without execute
+        assert_eq!(format_permissions(0o1776), "rwxrwxrwT");
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -12,10 +12,6 @@ use std::fs;
 use std::io::{self, Write};
 use url::Url;
 
-// Platform-specific import for unix permissions
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
 /// Executes the classic directory tree view
 pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     if !args.common.path.is_dir() {
@@ -38,21 +34,10 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     };
 
     let root_permissions_str = if args.common.permissions {
-        let perms = if let Some(md) = &root_metadata {
-            #[cfg(unix)]
-            {
-                let mode = md.permissions().mode();
-                let file_type_char = if md.is_dir() { 'd' } else { '-' };
-                format!("{}{}", file_type_char, utils::format_permissions(mode))
-            }
-            #[cfg(not(unix))]
-            {
-                let _ = md;
-                "----------".to_string()
-            }
-        } else {
-            "----------".to_string()
-        };
+        let perms = root_metadata
+            .as_ref()
+            .map(utils::permission_string)
+            .unwrap_or_else(|| "----------".to_string());
         format!("{perms} ")
     } else {
         String::new()
@@ -158,24 +143,10 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         let metadata =
             if args.common.size || args.common.permissions { entry.metadata().ok() } else { None };
         let permissions_str = if args.common.permissions {
-            let perms = if let Some(md) = &metadata {
-                // <-- Use 'md' here
-                #[cfg(unix)]
-                {
-                    // Use 'md' for Unix-specific logic
-                    let mode = md.permissions().mode();
-                    let file_type_char = if md.is_dir() { 'd' } else { '-' };
-                    format!("{}{}", file_type_char, utils::format_permissions(mode))
-                }
-                #[cfg(not(unix))]
-                {
-                    // This line tells the compiler we've intentionally not used 'md' on non-Unix systems
-                    let _ = md;
-                    "----------".to_string()
-                }
-            } else {
-                "----------".to_string()
-            };
+            let perms = metadata
+                .as_ref()
+                .map(utils::permission_string)
+                .unwrap_or_else(|| "----------".to_string());
             format!("{perms} ")
         } else {
             String::new()

--- a/src/view.rs
+++ b/src/view.rs
@@ -208,7 +208,10 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
             styled_name = styled_name.underline();
         }
 
-        let final_name = if args.hyperlinks && !is_dir {
+        // Hyperlink escapes follow the colorization decision so that
+        // `--color never` and piped output stay clean, pipeable text.
+        let final_name = if args.hyperlinks && !is_dir && control::SHOULD_COLORIZE.should_colorize()
+        {
             // Canonicalize the path to get an absolute path for the URL
             if let Ok(abs_path) = fs::canonicalize(entry.path()) {
                 if let Ok(url) = Url::from_file_path(abs_path) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -567,3 +567,25 @@ fn test_permissions_show_symlink_type() -> Result<(), Box<dyn std::error::Error>
     assert!(file_line.starts_with('-'), "file line should start with '-': {file_line}");
     Ok(())
 }
+
+#[test]
+fn test_hyperlinks_follow_colorization() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    fs::File::create(temp_dir.path().join("a.txt"))?;
+
+    // --color never must produce clean output with no OSC 8 escapes.
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--hyperlinks").arg("--color").arg("never").arg(temp_dir.path());
+    cmd.assert().success().stdout(predicate::str::contains("\x1b]8").not());
+
+    // Piped output (color auto) must also stay clean.
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--hyperlinks").arg(temp_dir.path());
+    cmd.assert().success().stdout(predicate::str::contains("\x1b]8").not());
+
+    // With colors forced on, hyperlinks are emitted.
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--hyperlinks").arg("--color").arg("always").arg(temp_dir.path());
+    cmd.assert().success().stdout(predicate::str::contains("\x1b]8"));
+    Ok(())
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -547,3 +547,23 @@ fn test_dirs_only_connectors() -> Result<(), Box<dyn std::error::Error>> {
         .stdout(predicate::str::contains("inner").not());
     Ok(())
 }
+
+#[test]
+#[cfg(unix)]
+fn test_permissions_show_symlink_type() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    fs::File::create(temp_dir.path().join("target.txt"))?;
+    std::os::unix::fs::symlink("target.txt", temp_dir.path().join("link_to_target"))?;
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("-p").arg(temp_dir.path());
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let link_line =
+        stdout.lines().find(|l| l.contains("link_to_target")).expect("symlink should be listed");
+    assert!(link_line.starts_with('l'), "symlink line should start with 'l': {link_line}");
+    let file_line =
+        stdout.lines().find(|l| l.contains("target.txt")).expect("file should be listed");
+    assert!(file_line.starts_with('-'), "file line should start with '-': {file_line}");
+    Ok(())
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -589,3 +589,39 @@ fn test_hyperlinks_follow_colorization() -> Result<(), Box<dyn std::error::Error
     cmd.assert().success().stdout(predicate::str::contains("\x1b]8"));
     Ok(())
 }
+
+#[test]
+fn test_git_status_propagates_to_directories() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    let temp_path = temp_dir.path();
+    Command::new("git").arg("init").current_dir(temp_path).output()?;
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(temp_path)
+        .output()?;
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(temp_path)
+        .output()?;
+
+    fs::create_dir(temp_path.join("subdir"))?;
+    fs::write(temp_path.join("subdir/inner.txt"), "one")?;
+    fs::write(temp_path.join("clean.txt"), "clean")?;
+    Command::new("git").args(["add", "."]).current_dir(temp_path).output()?;
+    Command::new("git").args(["commit", "-m", "init"]).current_dir(temp_path).output()?;
+    fs::write(temp_path.join("subdir/inner.txt"), "two")?;
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("-G").arg(temp_path);
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let dir_line = stdout.lines().find(|l| l.contains("subdir")).expect("subdir should be listed");
+    assert!(
+        dir_line.starts_with('M'),
+        "directory containing a modified file should show M: {dir_line}"
+    );
+    let clean_line =
+        stdout.lines().find(|l| l.contains("clean.txt")).expect("clean.txt should be listed");
+    assert!(clean_line.starts_with("  "), "clean file should have no marker: {clean_line}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

The remaining polish items from the code-review triage, one commit each:

1. **Permissions** — the permission string now shows `l` for symlinks and renders setuid/setgid/sticky bits (`s`/`S`, `t`/`T`) like `ls -l`. The formatting block that was copy-pasted three times (each with its own `#[cfg]` dance and `let _ = md;` suppressions) is now a shared `utils::permission_string()`.
2. **Hyperlinks follow colorization** — OSC 8 escapes were emitted even under `--color never` and into pipes, polluting output for exactly the users asking for clean text. Emission now follows the same decision as colors (matches `ls --hyperlink=auto` semantics).
3. **Mouse capture removed** — it was enabled with no `Event::Mouse` handler, so its only effect was breaking click-drag text selection in the terminal. Verified gone from the emitted escape sequences in a pty smoke test.
4. **Directory git status** — folders containing changed files now show a marker in both modes; each file's status propagates to its ancestors with the most severe status winning (conflicted > deleted > modified > typechange > renamed > new > untracked).
5. **Windows verbatim paths** (#24) — `utils::display_path()` converts `\\?\C:\...` and `\\?\UNC\...` back to conventional form for Ctrl+s output and editor invocations. Windows-specific unit tests run in the Windows CI job.

## Testing

- 29 unit + 24 CLI tests green (new: special-bit permission tests, symlink type-char CLI test, hyperlink-suppression CLI test, directory-status CLI test, Windows `display_path` tests), fmt/clippy clean
- All golden baselines match (the sample directory is clean in git, so `-G` baselines are unaffected by the propagation change)
- TUI smoke-tested in a pty: `-G -p` rendering, navigation, Ctrl+s path printing, clean exit, tty restored