### PR TITLE
Add AUR package to README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ The easiest way to install `lstr` on macOS is with Homebrew.
 brew install lstr
 ```
 
+### Arch Linux (AUR)
+
+A community-maintained [`lstr-git`](https://aur.archlinux.org/packages/lstr-git) package (thanks, [@bakatrouble](https://github.com/bakatrouble)!) builds the latest commit from this repository. Install it with your preferred AUR helper, e.g.:
+
+```bash
+paru -S lstr-git
+```
+
 ### From source (all platforms)
 
 You need the Rust toolchain installed on your system to build `lstr`.


### PR DESCRIPTION
Documents the community-maintained [`lstr-git`](https://aur.archlinux.org/packages/lstr-git) AUR package, crediting @bakatrouble. Addresses the README half of #15; package ownership/co-maintainership remains for the maintainer to decide on the issue.