### PR TITLE
Add --file-depth and --max-items display limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `--file-depth <LEVEL>` to hide individual files below a depth, summarized per directory as `[+N files]` — useful for high-level project overviews ([Closes #9](https://github.com/bgreenwell/lstr/issues/9))
+- Added `--max-items <N>` to cap entries shown per directory, summarizing the rest as `[+N more]` ([Closes #8](https://github.com/bgreenwell/lstr/issues/8))
 - Interactive mode now returns to the tree after closing the editor instead of exiting, preserving expansion and selection and picking up file changes ([Closes #3](https://github.com/bgreenwell/lstr/issues/3), [Closes #22](https://github.com/bgreenwell/lstr/issues/22))
 - Added `--editor <COMMAND>` to interactive mode for custom file openers, and `$VISUAL` is now honored before `$EDITOR` ([Closes #26](https://github.com/bgreenwell/lstr/issues/26))
 - Added `h`/`←` (collapse selected or parent directory) and `l`/`→` (expand/open) navigation keys in interactive mode ([Closes #41](https://github.com/bgreenwell/lstr/issues/41), thanks @Kr1ngl3)

--- a/src/app.rs
+++ b/src/app.rs
@@ -101,6 +101,14 @@ pub struct ViewArgs {
     /// Display directories only.
     #[arg(short = 'd', long)]
     pub dirs_only: bool,
+    /// Hide individual files below this depth, summarizing them per
+    /// directory as "[+N files]". Directories are always shown.
+    #[arg(long, value_name = "LEVEL")]
+    pub file_depth: Option<usize>,
+    /// Show at most this many entries per directory, summarizing the
+    /// rest as "[+N more]".
+    #[arg(long, value_name = "N")]
+    pub max_items: Option<usize>,
     /// Render file paths as clickable hyperlinks.
     #[arg(long)]
     pub hyperlinks: bool,

--- a/src/view.rs
+++ b/src/view.rs
@@ -108,10 +108,49 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     let sort_options = args.common.to_sort_options();
     sort::sort_entries_hierarchically(&mut entries, &sort_options);
 
-    // Build tree structure information
-    let tree_info = build_tree_info(&entries);
+    // The summary counts reflect the whole walked tree, including entries
+    // hidden by --file-depth / --max-items (they are represented by the
+    // "[+N ...]" markers).
+    for entry in &entries {
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+            dir_count += 1;
+        } else {
+            file_count += 1;
+        }
+    }
 
-    for (index, entry) in entries.iter().enumerate() {
+    let nodes = apply_display_limits(entries, args.file_depth, args.max_items);
+
+    // Build tree structure information
+    let depths: Vec<usize> = nodes.iter().map(TreeNode::depth).collect();
+    let tree_info = build_tree_info(&depths);
+
+    for (index, node) in nodes.iter().enumerate() {
+        let (prefix, connector) = &tree_info[index];
+
+        let entry = match node {
+            TreeNode::Entry(entry) => entry,
+            TreeNode::Summary { hidden_files, hidden_items, .. } => {
+                let git_col =
+                    if status_cache.is_some() && root_in_repo.is_some() { "  " } else { "" };
+                let perm_col = if args.common.permissions { " ".repeat(11) } else { String::new() };
+                let label = summary_label(*hidden_files, *hidden_items);
+                if writeln!(
+                    io::stdout(),
+                    "{}{}{}{} {}",
+                    git_col,
+                    perm_col,
+                    prefix,
+                    connector,
+                    label.dimmed()
+                )
+                .is_err()
+                {
+                    break;
+                }
+                continue;
+            }
+        };
         let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
 
         let git_status_str = if let (Some(cache), Some(base)) =
@@ -152,7 +191,6 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
             String::new()
         };
 
-        let (prefix, connector) = &tree_info[index];
         let name = entry.file_name().to_string_lossy();
         let icon_str = if args.common.icons {
             let (icon, color) = icons::get_icon_for_path(entry.path(), is_dir);
@@ -226,12 +264,6 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
             styled_name.to_string()
         };
 
-        if is_dir {
-            dir_count += 1;
-        } else {
-            file_count += 1;
-        }
-
         if writeln!(
             io::stdout(),
             "{}{}{}{} {}{}{}",
@@ -255,22 +287,111 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// A renderable line in the tree: a real entry, or a per-directory summary
+/// of entries hidden by `--file-depth` / `--max-items`.
+enum TreeNode {
+    Entry(ignore::DirEntry),
+    Summary { depth: usize, hidden_files: usize, hidden_items: usize },
+}
+
+impl TreeNode {
+    fn depth(&self) -> usize {
+        match self {
+            TreeNode::Entry(entry) => entry.depth(),
+            TreeNode::Summary { depth, .. } => *depth,
+        }
+    }
+}
+
+/// Applies the display limits, turning entries into renderable nodes. Each
+/// directory whose children were suppressed gets one trailing summary node.
+/// Entries suppressed by `--max-items` take their whole subtree with them.
+fn apply_display_limits(
+    entries: Vec<ignore::DirEntry>,
+    file_depth: Option<usize>,
+    max_items: Option<usize>,
+) -> Vec<TreeNode> {
+    if file_depth.is_none() && max_items.is_none() {
+        return entries.into_iter().map(TreeNode::Entry).collect();
+    }
+
+    use std::collections::HashMap;
+    let mut children_map: HashMap<std::path::PathBuf, Vec<ignore::DirEntry>> = HashMap::new();
+    let mut roots = Vec::new();
+    for entry in entries {
+        if entry.depth() == 1 {
+            roots.push(entry);
+        } else if let Some(parent) = entry.path().parent() {
+            children_map.entry(parent.to_path_buf()).or_default().push(entry);
+        }
+    }
+
+    fn emit(
+        children: Vec<ignore::DirEntry>,
+        children_map: &mut HashMap<std::path::PathBuf, Vec<ignore::DirEntry>>,
+        file_depth: Option<usize>,
+        max_items: Option<usize>,
+        out: &mut Vec<TreeNode>,
+    ) {
+        let child_depth = children.first().map(|e| e.depth()).unwrap_or(1);
+        let mut kept = 0usize;
+        let mut hidden_files = 0usize;
+        let mut hidden_items = 0usize;
+        for child in children {
+            let is_dir = child.file_type().is_some_and(|ft| ft.is_dir());
+            if !is_dir && file_depth.is_some_and(|limit| child.depth() > limit) {
+                hidden_files += 1;
+                continue;
+            }
+            if max_items.is_some_and(|limit| kept >= limit) {
+                hidden_items += 1;
+                continue;
+            }
+            kept += 1;
+            let grandchildren = children_map.remove(child.path());
+            out.push(TreeNode::Entry(child));
+            if let Some(grandchildren) = grandchildren {
+                emit(grandchildren, children_map, file_depth, max_items, out);
+            }
+        }
+        if hidden_files > 0 || hidden_items > 0 {
+            out.push(TreeNode::Summary { depth: child_depth, hidden_files, hidden_items });
+        }
+    }
+
+    let mut nodes = Vec::new();
+    emit(roots, &mut children_map, file_depth, max_items, &mut nodes);
+    nodes
+}
+
+/// Formats a summary node's label, e.g. "[+3 files]" or "[+1 file, +2 more]".
+fn summary_label(hidden_files: usize, hidden_items: usize) -> String {
+    let mut parts = Vec::new();
+    if hidden_files > 0 {
+        let noun = if hidden_files == 1 { "file" } else { "files" };
+        parts.push(format!("+{hidden_files} {noun}"));
+    }
+    if hidden_items > 0 {
+        parts.push(format!("+{hidden_items} more"));
+    }
+    format!("[{}]", parts.join(", "))
+}
+
 /// Builds tree structure information for proper connector display.
-/// Returns one (prefix, connector) pair per entry, in entry order.
+/// Returns one (prefix, connector) pair per node, in node order.
 ///
-/// Entries must be in depth-first order (each entry's parent precedes it),
-/// which `sort_entries_hierarchically` guarantees. Under that invariant an
-/// entry is the last of its siblings exactly when the next entry at a depth
+/// Nodes must be in depth-first order (each node's parent precedes it),
+/// which `sort_entries_hierarchically` guarantees. Under that invariant a
+/// node is the last of its siblings exactly when the next node at a depth
 /// less than or equal to its own is strictly shallower, so everything can be
-/// computed in two linear passes instead of rescanning the list per entry.
-fn build_tree_info(entries: &[ignore::DirEntry]) -> Vec<(String, &'static str)> {
-    // Reverse pass: pending[d] is true when a later entry at depth d exists
+/// computed in two linear passes instead of rescanning the list per node.
+fn build_tree_info(depths: &[usize]) -> Vec<(String, &'static str)> {
+    // Reverse pass: pending[d] is true when a later node at depth d exists
     // within the same parent scope (deeper flags are cleared whenever a
-    // shallower entry is seen, since those entries belong to its subtree).
-    let mut is_last = vec![false; entries.len()];
+    // shallower node is seen, since those nodes belong to its subtree).
+    let mut is_last = vec![false; depths.len()];
     let mut pending: Vec<bool> = Vec::new();
-    for (index, entry) in entries.iter().enumerate().rev() {
-        let depth = entry.depth();
+    for (index, &depth) in depths.iter().enumerate().rev() {
         if pending.len() <= depth {
             pending.resize(depth + 1, false);
         } else {
@@ -280,16 +401,15 @@ fn build_tree_info(entries: &[ignore::DirEntry]) -> Vec<(String, &'static str)> 
         pending[depth] = true;
     }
 
-    // Forward pass: build each entry's prefix from its ancestors' last-sibling
+    // Forward pass: build each node's prefix from its ancestors' last-sibling
     // flags, maintained as a stack indexed by depth.
-    let mut tree_info = Vec::with_capacity(entries.len());
+    let mut tree_info = Vec::with_capacity(depths.len());
     let mut prefix_parts: Vec<&'static str> = Vec::new();
-    for (index, entry) in entries.iter().enumerate() {
-        let depth = entry.depth();
+    for (index, &depth) in depths.iter().enumerate() {
         prefix_parts.truncate(depth.saturating_sub(1));
         let prefix = prefix_parts.concat();
         let connector = if is_last[index] { "└──" } else { "├──" };
-        // How this entry contributes to its descendants' prefixes.
+        // How this node contributes to its descendants' prefixes.
         prefix_parts.push(if is_last[index] { "    " } else { "│   " });
         tree_info.push((prefix, connector));
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -625,3 +625,43 @@ fn test_git_status_propagates_to_directories() -> Result<(), Box<dyn std::error:
     assert!(clean_line.starts_with("  "), "clean file should have no marker: {clean_line}");
     Ok(())
 }
+
+#[test]
+fn test_file_depth_limit() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    fs::create_dir(temp_dir.path().join("adir"))?;
+    fs::write(temp_dir.path().join("adir/deep1.txt"), "x")?;
+    fs::write(temp_dir.path().join("adir/deep2.txt"), "x")?;
+    fs::write(temp_dir.path().join("top.txt"), "x")?;
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--file-depth").arg("1").arg(temp_dir.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("top.txt"))
+        .stdout(predicate::str::contains("adir"))
+        .stdout(predicate::str::contains("deep1.txt").not())
+        .stdout(predicate::str::contains("[+2 files]"));
+    Ok(())
+}
+
+#[test]
+fn test_max_items_limit() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    for name in ["a1.txt", "a2.txt", "a3.txt", "a4.txt"] {
+        fs::write(temp_dir.path().join(name), "x")?;
+    }
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--max-items").arg("2").arg(temp_dir.path());
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("a1.txt") && stdout.contains("a2.txt"), "{stdout}");
+    assert!(!stdout.contains("a3.txt") && !stdout.contains("a4.txt"), "{stdout}");
+    // Kept entries keep mid-list connectors; the summary is the last child.
+    assert!(stdout.contains("├── a2.txt"), "{stdout}");
+    assert!(stdout.contains("└── [+2 more]"), "{stdout}");
+    // The summary counts suppressed entries in the totals.
+    assert!(stdout.contains("4 files"), "{stdout}");
+    Ok(())
+}


### PR DESCRIPTION
Closes #9, closes #8.

- `--file-depth <LEVEL>`: files below the depth are hidden and summarized per directory as `[+N files]`; directories always show. Made for high-level overviews (the LLM-context use case from #9).
- `--max-items <N>`: each directory shows at most N entries (in sorted order) with a `[+N more]` summary; suppressing a directory suppresses its subtree.
- Both compose with each other and with `-p`/`-G` column alignment; summary lines render dimmed with correct tree connectors (always the last child).
- Internals: rendering now iterates a `TreeNode` list (entry or summary) and `build_tree_info` takes plain depths — the same hook a JSON/HTML backend can reuse for #7.
- Totals still count suppressed entries, since the `[+N]` markers represent them.

Two new CLI tests (written first, red before the implementation); full suite green (34 unit + 26 CLI), fmt/clippy clean, all baselines match.