### PR TITLE
Add --output json for machine-readable classic output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `--output json` for machine-readable classic-mode output, including sizes, permissions, and git status when the matching flags are set (progress toward [#7](https://github.com/bgreenwell/lstr/issues/7))
 - Added mouse support in interactive mode: scroll wheel moves the selection, click selects, and clicking the selected entry opens/toggles it ([Closes #28](https://github.com/bgreenwell/lstr/issues/28))
 - Added `--file-depth <LEVEL>` to hide individual files below a depth, summarized per directory as `[+N files]` — useful for high-level project overviews ([Closes #9](https://github.com/bgreenwell/lstr/issues/9))
 - Added `--max-items <N>` to cap entries shown per directory, summarizing the rest as `[+N more]` ([Closes #8](https://github.com/bgreenwell/lstr/issues/8))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "natord",
  "predicates",
  "ratatui",
+ "serde_json",
  "tempfile",
  "url",
 ]
@@ -928,6 +929,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lscolors = "0.9"
 url = "2.5.2"
 ratatui = "0.27.0"
 natord = "1.0"
+serde_json = "1.0"
 
 # Dependencies for testing the command-line interface
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Note that `PATH` defaults to the current directory (`.`) if not specified.
 | `--icons`              | Display file-specific icons; requires a [Nerd Font](https://www.nerdfonts.com/). |
 | `--hyperlinks`         | Render file paths as clickable hyperlinks (classic mode only)               |
 | `-L`, `--level <LEVEL>`| Maximum depth to descend.                                                   |
+| `--file-depth <LEVEL>` | Hide individual files below this depth, summarized as `[+N files]` (classic mode only). |
+| `--max-items <N>`      | Show at most N entries per directory, summarized as `[+N more]` (classic mode only). |
+| `--output <FORMAT>`    | Output format: `text` (default) or `json` (classic mode only).              |
 | `-p`, `--permissions`  | Display file permissions (Unix-like systems only).                          |
 | `-s`, `--size`         | Display the size of files.                                                  |
 | `--sort <TYPE>`        | Sort entries by the specified criteria (`name`, `size`, `modified`, `extension`). |
@@ -96,6 +99,7 @@ Note that `PATH` defaults to the current directory (`.`) if not specified.
 | `-r`, `--reverse`      | Reverse the sort order.                                                     |
 | `--dotfiles-first`     | Sort dotfiles and dotfolders first (dotfolders → folders → dotfiles → files). |
 | `--expand-level <LEVEL>`| **Interactive mode only:** Initial depth to expand the interactive tree.   |
+| `--editor <COMMAND>`   | **Interactive mode only:** Command used to open files, overriding `$VISUAL`/`$EDITOR`. |
 
 -----
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -112,6 +112,26 @@ pub struct ViewArgs {
     /// Render file paths as clickable hyperlinks.
     #[arg(long)]
     pub hyperlinks: bool,
+    /// Output format for the tree.
+    #[arg(long, value_name = "FORMAT", default_value_t = OutputFormat::Text)]
+    pub output: OutputFormat,
+}
+
+/// Defines the available output formats for the classic view.
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    /// Human-readable tree (default)
+    #[default]
+    Text,
+    /// Machine-readable JSON
+    Json,
+}
+
+/// Implements the Display trait for OutputFormat to show possible values in help messages.
+impl fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.to_possible_value().expect("no values are skipped").get_name().fmt(f)
+    }
 }
 
 /// Arguments for the `interactive` command.

--- a/src/view.rs
+++ b/src/view.rs
@@ -26,39 +26,43 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         crate::app::ColorChoice::Auto => {}
     }
 
-    // Format root directory with same alignment as tree entries
-    let root_metadata = if args.common.size || args.common.permissions {
-        fs::metadata(&args.common.path).ok()
-    } else {
-        None
-    };
+    let text_mode = args.output == crate::app::OutputFormat::Text;
 
-    let root_permissions_str = if args.common.permissions {
-        let perms = root_metadata
-            .as_ref()
-            .map(utils::permission_string)
-            .unwrap_or_else(|| "----------".to_string());
-        format!("{perms} ")
-    } else {
-        String::new()
-    };
+    if text_mode {
+        // Format root directory with same alignment as tree entries
+        let root_metadata = if args.common.size || args.common.permissions {
+            fs::metadata(&args.common.path).ok()
+        } else {
+            None
+        };
 
-    let root_git_status_str = if args.common.git_status {
-        "  ".to_string() // Empty git status column for consistent spacing
-    } else {
-        String::new()
-    };
+        let root_permissions_str = if args.common.permissions {
+            let perms = root_metadata
+                .as_ref()
+                .map(utils::permission_string)
+                .unwrap_or_else(|| "----------".to_string());
+            format!("{perms} ")
+        } else {
+            String::new()
+        };
 
-    if writeln!(
-        io::stdout(),
-        "{}{}{}",
-        root_git_status_str,
-        root_permissions_str,
-        args.common.path.display().to_string().blue().bold()
-    )
-    .is_err()
-    {
-        return Ok(());
+        let root_git_status_str = if args.common.git_status {
+            "  ".to_string() // Empty git status column for consistent spacing
+        } else {
+            String::new()
+        };
+
+        if writeln!(
+            io::stdout(),
+            "{}{}{}",
+            root_git_status_str,
+            root_permissions_str,
+            args.common.path.display().to_string().blue().bold()
+        )
+        .is_err()
+        {
+            return Ok(());
+        }
     }
 
     let git_repo_status =
@@ -120,6 +124,13 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     }
 
     let nodes = apply_display_limits(entries, args.file_depth, args.max_items);
+
+    if !text_mode {
+        let json =
+            render_json(args, &nodes, dir_count, file_count, status_cache, root_in_repo.as_ref());
+        let _ = writeln!(io::stdout(), "{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
 
     // Build tree structure information
     let depths: Vec<usize> = nodes.iter().map(TreeNode::depth).collect();
@@ -285,6 +296,112 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
     _ = writeln!(io::stdout(), "{summary}");
 
     Ok(())
+}
+
+/// Renders the node list as a nested JSON document (loosely modeled on
+/// `tree -J`): the root object has `path`, `type`, `contents`, and a
+/// `report` with the directory/file totals. Optional per-entry fields
+/// (`size`, `permissions`, `git_status`) appear when the matching flags
+/// are set; summary markers from the display limits become
+/// `{"type": "summary", ...}` objects.
+fn render_json(
+    args: &ViewArgs,
+    nodes: &[TreeNode],
+    dir_count: usize,
+    file_count: usize,
+    status_cache: Option<&git::StatusCache>,
+    root_in_repo: Option<&std::path::PathBuf>,
+) -> serde_json::Value {
+    use serde_json::{json, Map, Value};
+
+    fn build_level(
+        nodes: &[TreeNode],
+        index: &mut usize,
+        depth: usize,
+        args: &ViewArgs,
+        status_cache: Option<&git::StatusCache>,
+        root_in_repo: Option<&std::path::PathBuf>,
+    ) -> Vec<Value> {
+        let mut out = Vec::new();
+        while *index < nodes.len() && nodes[*index].depth() == depth {
+            match &nodes[*index] {
+                TreeNode::Summary { hidden_files, hidden_items, .. } => {
+                    *index += 1;
+                    let mut object = Map::new();
+                    object.insert("type".into(), "summary".into());
+                    if *hidden_files > 0 {
+                        object.insert("hidden_files".into(), (*hidden_files).into());
+                    }
+                    if *hidden_items > 0 {
+                        object.insert("hidden_items".into(), (*hidden_items).into());
+                    }
+                    out.push(Value::Object(object));
+                }
+                TreeNode::Entry(entry) => {
+                    *index += 1;
+                    let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
+                    let type_str = if is_dir {
+                        "directory"
+                    } else if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+                        "symlink"
+                    } else {
+                        "file"
+                    };
+
+                    let mut object = Map::new();
+                    object.insert(
+                        "name".into(),
+                        entry.file_name().to_string_lossy().into_owned().into(),
+                    );
+                    object.insert("type".into(), type_str.into());
+
+                    let metadata = if args.common.size || args.common.permissions {
+                        entry.metadata().ok()
+                    } else {
+                        None
+                    };
+                    if args.common.size && !is_dir {
+                        if let Some(md) = &metadata {
+                            object.insert("size".into(), md.len().into());
+                        }
+                    }
+                    if args.common.permissions {
+                        if let Some(md) = &metadata {
+                            object
+                                .insert("permissions".into(), utils::permission_string(md).into());
+                        }
+                    }
+                    if let (Some(cache), Some(base)) = (status_cache, root_in_repo) {
+                        if let Some(status) = entry
+                            .path()
+                            .strip_prefix(&args.common.path)
+                            .ok()
+                            .and_then(|rel| cache.get(&base.join(rel)))
+                        {
+                            object
+                                .insert("git_status".into(), status.get_char().to_string().into());
+                        }
+                    }
+                    if is_dir {
+                        let children =
+                            build_level(nodes, index, depth + 1, args, status_cache, root_in_repo);
+                        object.insert("contents".into(), Value::Array(children));
+                    }
+                    out.push(Value::Object(object));
+                }
+            }
+        }
+        out
+    }
+
+    let mut index = 0;
+    let contents = build_level(nodes, &mut index, 1, args, status_cache, root_in_repo);
+    json!({
+        "path": args.common.path.display().to_string(),
+        "type": "directory",
+        "contents": contents,
+        "report": { "directories": dir_count, "files": file_count },
+    })
 }
 
 /// A renderable line in the tree: a real entry, or a per-directory summary

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -665,3 +665,32 @@ fn test_max_items_limit() -> Result<(), Box<dyn std::error::Error>> {
     assert!(stdout.contains("4 files"), "{stdout}");
     Ok(())
 }
+
+#[test]
+fn test_json_output() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    fs::create_dir(temp_dir.path().join("sub"))?;
+    fs::write(temp_dir.path().join("sub/inner.txt"), "hello")?;
+    fs::write(temp_dir.path().join("we\"ird name.txt"), "x")?;
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--output").arg("json").arg("-s").arg(temp_dir.path());
+    let output = cmd.output()?;
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+
+    assert_eq!(json["type"], "directory");
+    let contents = json["contents"].as_array().expect("root contents");
+    let sub = contents.iter().find(|e| e["name"] == "sub").expect("sub dir present");
+    assert_eq!(sub["type"], "directory");
+    let inner = &sub["contents"].as_array().expect("sub contents")[0];
+    assert_eq!(inner["name"], "inner.txt");
+    assert_eq!(inner["type"], "file");
+    assert_eq!(inner["size"], 5);
+    // Quote in the filename must be escaped correctly (parse already proves
+    // it; also check the value round-trips).
+    assert!(contents.iter().any(|e| e["name"] == "we\"ird name.txt"));
+    assert_eq!(json["report"]["directories"], 1);
+    assert_eq!(json["report"]["files"], 2);
+    Ok(())
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -671,7 +671,10 @@ fn test_json_output() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempdir()?;
     fs::create_dir(temp_dir.path().join("sub"))?;
     fs::write(temp_dir.path().join("sub/inner.txt"), "hello")?;
-    fs::write(temp_dir.path().join("we\"ird name.txt"), "x")?;
+    // Quotes are illegal in Windows filenames, so the JSON-escaping check
+    // runs on Unix only; Windows still checks the rest of the structure.
+    let weird_name = if cfg!(windows) { "weird name.txt" } else { "we\"ird name.txt" };
+    fs::write(temp_dir.path().join(weird_name), "x")?;
 
     let mut cmd = Command::cargo_bin("lstr")?;
     cmd.arg("--output").arg("json").arg("-s").arg(temp_dir.path());
@@ -689,7 +692,7 @@ fn test_json_output() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(inner["size"], 5);
     // Quote in the filename must be escaped correctly (parse already proves
     // it; also check the value round-trips).
-    assert!(contents.iter().any(|e| e["name"] == "we\"ird name.txt"));
+    assert!(contents.iter().any(|e| e["name"] == weird_name));
     assert_eq!(json["report"]["directories"], 1);
     assert_eq!(json["report"]["files"], 2);
     Ok(())


### PR DESCRIPTION
Progress toward #7 (JSON first, as discussed there; an HTML backend can reuse the same `TreeNode` hook).

- `--output <FORMAT>` on classic mode: `text` (default) or `json`
- Nested structure loosely modeled on `tree -J`: root object with `path`, `type`, `contents`, and a `report` of directory/file totals
- Per-entry `size`, `permissions`, and `git_status` fields appear when `-s`/`-p`/`-G` are set; `--file-depth`/`--max-items` markers serialize as `{"type": "summary", ...}` objects; symlinks get `"type": "symlink"`
- All serialization goes through `serde_json` (new dependency), so quoting/escaping is correct by construction — pinned by a CLI test with a quote in a filename

## Testing

New CLI test parses the output and checks structure, sizes, escaping, and report counts. Full suite green (37 unit + 27 CLI), fmt/clippy clean, baselines match.

**Stacked on #53.**