### PR TITLE
Add --du for cumulative directory sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `--du` to show directories with the cumulative size of their contents (like `tree --du`, implies `-s`); the summary line and JSON report include the total ([Closes #12](https://github.com/bgreenwell/lstr/issues/12))
 - Added `--output json` for machine-readable classic-mode output, including sizes, permissions, and git status when the matching flags are set (progress toward [#7](https://github.com/bgreenwell/lstr/issues/7))
 - Added mouse support in interactive mode: scroll wheel moves the selection, click selects, and clicking the selected entry opens/toggles it ([Closes #28](https://github.com/bgreenwell/lstr/issues/28))
 - Added `--file-depth <LEVEL>` to hide individual files below a depth, summarized per directory as `[+N files]` — useful for high-level project overviews ([Closes #9](https://github.com/bgreenwell/lstr/issues/9))

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Note that `PATH` defaults to the current directory (`.`) if not specified.
 | `-L`, `--level <LEVEL>`| Maximum depth to descend.                                                   |
 | `--file-depth <LEVEL>` | Hide individual files below this depth, summarized as `[+N files]` (classic mode only). |
 | `--max-items <N>`      | Show at most N entries per directory, summarized as `[+N more]` (classic mode only). |
+| `--du`                 | Show directories with the cumulative size of their contents, like `tree --du`; implies `-s` (classic mode only). |
 | `--output <FORMAT>`    | Output format: `text` (default) or `json` (classic mode only).              |
 | `-p`, `--permissions`  | Display file permissions (Unix-like systems only).                          |
 | `-s`, `--size`         | Display the size of files.                                                  |

--- a/src/app.rs
+++ b/src/app.rs
@@ -109,6 +109,10 @@ pub struct ViewArgs {
     /// rest as "[+N more]".
     #[arg(long, value_name = "N")]
     pub max_items: Option<usize>,
+    /// Show directories with the cumulative size of their contents,
+    /// like `tree --du` (implies -s).
+    #[arg(long)]
+    pub du: bool,
     /// Render file paths as clickable hyperlinks.
     #[arg(long)]
     pub hyperlinks: bool,

--- a/src/view.rs
+++ b/src/view.rs
@@ -123,11 +123,27 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         }
     }
 
+    // Cumulative sizes are computed over the full entry list, before any
+    // display limits, so a directory's size stays truthful even when its
+    // children are hidden.
+    let du_sizes = if args.du { Some(compute_cumulative_sizes(&entries)) } else { None };
+    let du_map = du_sizes.as_ref().map(|(map, _)| map);
+    let du_total = du_sizes.as_ref().map(|(_, total)| *total);
+    let size_enabled = args.common.size || args.du;
+
     let nodes = apply_display_limits(entries, args.file_depth, args.max_items);
 
     if !text_mode {
-        let json =
-            render_json(args, &nodes, dir_count, file_count, status_cache, root_in_repo.as_ref());
+        let json = render_json(
+            args,
+            &nodes,
+            dir_count,
+            file_count,
+            status_cache,
+            root_in_repo.as_ref(),
+            du_map,
+            du_total,
+        );
         let _ = writeln!(io::stdout(), "{}", serde_json::to_string_pretty(&json)?);
         return Ok(());
     }
@@ -191,7 +207,7 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         };
 
         let metadata =
-            if args.common.size || args.common.permissions { entry.metadata().ok() } else { None };
+            if size_enabled || args.common.permissions { entry.metadata().ok() } else { None };
         let permissions_str = if args.common.permissions {
             let perms = metadata
                 .as_ref()
@@ -209,7 +225,13 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         } else {
             String::new()
         };
-        let size_str = if args.common.size && !is_dir {
+        let size_str = if size_enabled && is_dir {
+            // Directories only carry a size under --du (cumulative).
+            du_map
+                .and_then(|map| map.get(entry.path()))
+                .map(|size| format!(" ({})", utils::format_size(*size)))
+                .unwrap_or_default()
+        } else if size_enabled {
             metadata
                 .as_ref()
                 .map(|m| format!(" ({})", utils::format_size(m.len())))
@@ -292,10 +314,54 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         }
     }
 
-    let summary = format!("\n{dir_count} directories, {file_count} files");
+    let summary = match du_total {
+        Some(total) => format!(
+            "\n{} used in {dir_count} directories, {file_count} files",
+            utils::format_size(total)
+        ),
+        None => format!("\n{dir_count} directories, {file_count} files"),
+    };
     _ = writeln!(io::stdout(), "{summary}");
 
     Ok(())
+}
+
+/// Computes each entry's cumulative apparent size (its own stat size plus,
+/// for directories, everything beneath it), keyed by path — the same
+/// accounting as `tree --du`. Returns the map and the grand total of the
+/// top-level entries.
+///
+/// Entries must be in depth-first order: a forward pass records each
+/// entry's parent index, then a reverse pass rolls sizes up, so the whole
+/// computation is O(n) with one `stat` per entry.
+fn compute_cumulative_sizes(
+    entries: &[ignore::DirEntry],
+) -> (std::collections::HashMap<std::path::PathBuf, u64>, u64) {
+    let mut sizes: Vec<u64> =
+        entries.iter().map(|e| e.metadata().ok().map(|m| m.len()).unwrap_or(0)).collect();
+
+    let mut parent_index: Vec<Option<usize>> = vec![None; entries.len()];
+    let mut ancestors: Vec<usize> = Vec::new(); // ancestors[k] is at depth k + 1
+    for (index, entry) in entries.iter().enumerate() {
+        ancestors.truncate(entry.depth().saturating_sub(1));
+        parent_index[index] = ancestors.last().copied();
+        ancestors.push(index);
+    }
+
+    for index in (0..entries.len()).rev() {
+        if let Some(parent) = parent_index[index] {
+            sizes[parent] += sizes[index];
+        }
+    }
+
+    let total = entries
+        .iter()
+        .zip(&sizes)
+        .filter(|(entry, _)| entry.depth() == 1)
+        .map(|(_, size)| size)
+        .sum();
+    let map = entries.iter().zip(sizes).map(|(e, s)| (e.path().to_path_buf(), s)).collect();
+    (map, total)
 }
 
 /// Renders the node list as a nested JSON document (loosely modeled on
@@ -304,6 +370,7 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
 /// (`size`, `permissions`, `git_status`) appear when the matching flags
 /// are set; summary markers from the display limits become
 /// `{"type": "summary", ...}` objects.
+#[allow(clippy::too_many_arguments)]
 fn render_json(
     args: &ViewArgs,
     nodes: &[TreeNode],
@@ -311,6 +378,8 @@ fn render_json(
     file_count: usize,
     status_cache: Option<&git::StatusCache>,
     root_in_repo: Option<&std::path::PathBuf>,
+    du_map: Option<&std::collections::HashMap<std::path::PathBuf, u64>>,
+    du_total: Option<u64>,
 ) -> serde_json::Value {
     use serde_json::{json, Map, Value};
 
@@ -321,6 +390,7 @@ fn render_json(
         args: &ViewArgs,
         status_cache: Option<&git::StatusCache>,
         root_in_repo: Option<&std::path::PathBuf>,
+        du_map: Option<&std::collections::HashMap<std::path::PathBuf, u64>>,
     ) -> Vec<Value> {
         let mut out = Vec::new();
         while *index < nodes.len() && nodes[*index].depth() == depth {
@@ -355,12 +425,18 @@ fn render_json(
                     );
                     object.insert("type".into(), type_str.into());
 
-                    let metadata = if args.common.size || args.common.permissions {
+                    let size_enabled = args.common.size || args.du;
+                    let metadata = if size_enabled || args.common.permissions {
                         entry.metadata().ok()
                     } else {
                         None
                     };
-                    if args.common.size && !is_dir {
+                    if size_enabled && is_dir {
+                        // Directories only carry a size under --du.
+                        if let Some(size) = du_map.and_then(|map| map.get(entry.path())) {
+                            object.insert("size".into(), (*size).into());
+                        }
+                    } else if size_enabled {
                         if let Some(md) = &metadata {
                             object.insert("size".into(), md.len().into());
                         }
@@ -383,8 +459,15 @@ fn render_json(
                         }
                     }
                     if is_dir {
-                        let children =
-                            build_level(nodes, index, depth + 1, args, status_cache, root_in_repo);
+                        let children = build_level(
+                            nodes,
+                            index,
+                            depth + 1,
+                            args,
+                            status_cache,
+                            root_in_repo,
+                            du_map,
+                        );
                         object.insert("contents".into(), Value::Array(children));
                     }
                     out.push(Value::Object(object));
@@ -395,12 +478,18 @@ fn render_json(
     }
 
     let mut index = 0;
-    let contents = build_level(nodes, &mut index, 1, args, status_cache, root_in_repo);
+    let contents = build_level(nodes, &mut index, 1, args, status_cache, root_in_repo, du_map);
+    let mut report = Map::new();
+    report.insert("directories".into(), dir_count.into());
+    report.insert("files".into(), file_count.into());
+    if let Some(total) = du_total {
+        report.insert("total_size".into(), total.into());
+    }
     json!({
         "path": args.common.path.display().to_string(),
         "type": "directory",
         "contents": contents,
-        "report": { "directories": dir_count, "files": file_count },
+        "report": report,
     })
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -697,3 +697,48 @@ fn test_json_output() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(json["report"]["files"], 2);
     Ok(())
 }
+
+#[test]
+fn test_du_cumulative_directory_sizes() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    fs::create_dir(temp_dir.path().join("sub"))?;
+    fs::write(temp_dir.path().join("sub/file1.txt"), vec![b'x'; 100])?;
+    fs::write(temp_dir.path().join("sub/file2.txt"), vec![b'x'; 50])?;
+    fs::write(temp_dir.path().join("top.txt"), vec![b'x'; 10])?;
+
+    // --du implies -s and shows cumulative sizes on directories.
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--du").arg(temp_dir.path());
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let sub_line = stdout.lines().find(|l| l.contains("sub (")).expect("sub should show a size");
+    // Cumulative size is at least the 150 bytes of contents. The directory
+    // entry's own stat size is platform-dependent (can push into KiB on
+    // ext4), so parse the human-readable value with its unit.
+    let inside = sub_line.split('(').nth(1).expect("size after name");
+    let mut parts = inside.split_whitespace();
+    let number: f64 = parts.next().and_then(|s| s.parse().ok()).expect("numeric size");
+    let unit = parts.next().expect("unit").trim_end_matches(')');
+    let bytes = match unit {
+        "B" => number,
+        "KiB" => number * 1024.0,
+        other => panic!("unexpected unit {other} in {sub_line}"),
+    };
+    assert!(bytes >= 150.0, "cumulative size should include contents: {sub_line}");
+    assert!(stdout.contains("file1.txt (100 B)"), "{stdout}");
+    assert!(stdout.contains("used in 1 directories, 3 files"), "{stdout}");
+
+    // JSON output carries directory sizes too.
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--du").arg("--output").arg("json").arg(temp_dir.path());
+    let json: serde_json::Value = serde_json::from_slice(&cmd.output()?.stdout)?;
+    let sub = json["contents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["name"] == "sub")
+        .expect("sub in json");
+    assert!(sub["size"].as_u64().expect("dir size present") >= 150);
+    assert!(json["report"]["total_size"].as_u64().expect("total present") >= 160);
+    Ok(())
+}


### PR DESCRIPTION
Closes #12 (the "dir size (volume)" request — `tree --du` semantics).

- `--du` (classic mode, implies `-s`): directories display the cumulative apparent size of everything beneath them
- Accounting matches `tree --du` — each directory's own stat size is included, verified against `tree` on the same fixture (per-directory numbers identical: 320/160 bytes). The *summary total* intentionally differs from tree's: lstr sums the displayed top-level entries and doesn't count the walk root itself, consistent with its existing directory/file counts
- Computed in O(n): a forward pass records parent indices over the DFS-ordered entries, a reverse pass rolls sizes up — one `stat` per entry, no extra I/O
- Sizes are computed **before** `--file-depth`/`--max-items` suppression, so a directory's size stays truthful when its children are hidden
- Summary line becomes `<total> used in X directories, Y files`; `--output json` gains `size` on directories and `report.total_size`

## Testing

New CLI test (written first, red before implementation) covering text and JSON output, with unit-aware size parsing so it holds on ext4 where directory entries are 4 KiB. Full suite green (37 unit + 28 CLI), fmt/clippy clean, baselines match.