### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.x.y] - YYYY-MM-DD (Unreleased)
+## [Unreleased]
+
+## [0.3.0] - 2026-07-12
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "lstr"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lstr"
-version = "0.2.1" 
+version = "0.3.0"
 authors = ["Brandon Greenwell <greenwell.brandon@gmail.com>"]
 edition = "2021"
 description = "A blazingly fast, minimalist directory tree viewer, written in Rust."


### PR DESCRIPTION
Version bump to 0.3.0 and changelog roll: the `[Unreleased]` section becomes `[0.3.0] - 2026-07-12`, with a fresh empty `[Unreleased]` on top.

Pre-release checks: fmt/clippy/tests green, all golden baselines match, `cargo publish --dry-run` packages cleanly. Tag `v0.3.0` follows after merge, triggering the new cargo-dist pipeline (all five publishing secrets are now set).