### PR TITLE
Make AUR publishing manual until co-maintainer access exists

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,8 +1,9 @@
 name: Publish to AUR
 
+# Manual-only for now: the AUR lstr-bin package is community-maintained
+# (by Dominiquini), so this workflow cannot push until co-maintainer
+# access is arranged (see issue #15). Re-add the tag trigger then.
 on:
-  push:
-    tags: ['v*']
   workflow_dispatch:
     inputs:
       tag:

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -45,11 +45,11 @@ All of the following are now automated via GitHub Actions:
   - Manual: `cargo publish` from the tagged commit (not automated)
 
 - [ ] **AUR** package updated at [lstr-bin](https://aur.archlinux.org/packages/lstr-bin)
-  - Automated by: `.github/workflows/publish-aur.yml`
-  - PKGBUILD and .SRCINFO auto-generated and pushed
-  - **First release:** the `lstr-bin` package must exist under the AUR
-    account whose SSH key is in `AUR_SSH_PRIVATE_KEY` (the community
-    `lstr-git` package is separate; see issue #15)
+  - Currently **community-maintained** (by Dominiquini; `lstr-git` by
+    bakatrouble is also community-maintained — see issue #15). Verify the
+    maintainer picks up the new version, or nudge on the AUR page.
+  - `.github/workflows/publish-aur.yml` is manual-only until co-maintainer
+    access is arranged; then restore its tag trigger.
 
 - [ ] **WinGet** manifest PR created to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
   - Automated by: `.github/workflows/publish-winget.yml`


### PR DESCRIPTION
The v0.3.0 release surfaced that [`lstr-bin`](https://aur.archlinux.org/packages/lstr-bin) already exists on the AUR, community-maintained by Dominiquini (in addition to bakatrouble's `lstr-git`). Our publish workflow authenticated fine but was denied push access, and it would fail on every future tag.

This drops the tag trigger from `publish-aur.yml` (keeping `workflow_dispatch` for when co-maintainer access is arranged per #15) and updates the release checklist to reflect that AUR is community-maintained for now.