### PR TITLE
Wait for release assets in publish workflows

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -32,6 +32,24 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+      # The Release workflow triggered by the same tag builds the assets;
+      # wait for the one we need instead of racing it (fails after ~30 min).
+      - name: Wait for release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.get-version.outputs.tag }}"
+          echo "Waiting for lstr-x86_64-unknown-linux-gnu.tar.xz on release $TAG..."
+          for i in $(seq 1 40); do
+            if gh release view "$TAG" --repo ${{ github.repository }} --json assets \
+                 --jq '.assets[].name' 2>/dev/null | grep -qx "lstr-x86_64-unknown-linux-gnu.tar.xz"; then
+              echo "Release asset found."
+              exit 0
+            fi
+            sleep 45
+          done
+          echo "Timed out waiting for release asset lstr-x86_64-unknown-linux-gnu.tar.xz" >&2
+          exit 1
       - name: Checkout lstr repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-scoop.yml
+++ b/.github/workflows/publish-scoop.yml
@@ -32,6 +32,24 @@ jobs:
             echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
+      # The Release workflow triggered by the same tag builds the assets;
+      # wait for the one we need instead of racing it (fails after ~30 min).
+      - name: Wait for release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.get-tag.outputs.tag }}"
+          echo "Waiting for lstr-x86_64-pc-windows-msvc.zip on release $TAG..."
+          for i in $(seq 1 40); do
+            if gh release view "$TAG" --repo ${{ github.repository }} --json assets \
+                 --jq '.assets[].name' 2>/dev/null | grep -qx "lstr-x86_64-pc-windows-msvc.zip"; then
+              echo "Release asset found."
+              exit 0
+            fi
+            sleep 45
+          done
+          echo "Timed out waiting for release asset lstr-x86_64-pc-windows-msvc.zip" >&2
+          exit 1
       - name: Checkout Scoop bucket
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -31,6 +31,24 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+      # The Release workflow triggered by the same tag builds the assets;
+      # wait for the one we need instead of racing it (fails after ~30 min).
+      - name: Wait for release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.get-version.outputs.tag }}"
+          echo "Waiting for lstr-x86_64-pc-windows-msvc.msi on release $TAG..."
+          for i in $(seq 1 40); do
+            if gh release view "$TAG" --repo ${{ github.repository }} --json assets \
+                 --jq '.assets[].name' 2>/dev/null | grep -qx "lstr-x86_64-pc-windows-msvc.msi"; then
+              echo "Release asset found."
+              exit 0
+            fi
+            sleep 45
+          done
+          echo "Timed out waiting for release asset lstr-x86_64-pc-windows-msvc.msi" >&2
+          exit 1
       - name: Install Komac
         uses: cargo-bins/cargo-binstall@v1.20.1
 


### PR DESCRIPTION
The v0.3.0 release showed all three publish workflows failing by racing the Release build: they trigger on the same tag push, but the assets they download don't exist until cargo-dist finishes (~10 minutes), so every release needed manual re-dispatch.

Each workflow now polls `gh release view` for the specific asset it needs (zip for Scoop, MSI for WinGet, linux-gnu tarball for AUR) for up to 30 minutes before proceeding. Manual `workflow_dispatch` runs pass through immediately since the asset already exists. The same fix is going to xleak and doxx, which inherited the identical race.