### PR TITLE
Standardize README badges to the shared for-the-badge template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # lstr
 
-[![Build Status](https://github.com/bgreenwell/lstr/actions/workflows/ci.yml/badge.svg)](https://github.com/bgreenwell/lstr/actions)
-[![Latest Version](https://img.shields.io/crates/v/lstr.svg)](https://crates.io/crates/lstr)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://img.shields.io/github/actions/workflow/status/bgreenwell/lstr/ci.yml?style=for-the-badge)](https://github.com/bgreenwell/lstr/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/lstr.svg?style=for-the-badge&color=%234E9A06)](https://crates.io/crates/lstr)
+[![Downloads](https://img.shields.io/crates/d/lstr?style=for-the-badge&color=%234E9A06)](https://crates.io/crates/lstr)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-%232196F3.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
+[![Rust](https://img.shields.io/badge/rust-1.70%2B-%23D34516.svg?style=for-the-badge&logo=rust&logoColor=white)](https://www.rust-lang.org/)
+[![Easy Install](https://img.shields.io/badge/Easy%20Install-Homebrew%20%7C%20Scoop%20%7C%20WinGet-%23FBB040?style=for-the-badge)](#installation)
+[![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20macOS%20%7C%20Windows-blue?style=for-the-badge)](https://github.com/bgreenwell/lstr/releases/latest)
 
 A fast, minimalist directory tree viewer, written in Rust. Inspired by the command line program [tree](https://github.com/Old-Man-Programmer/tree), with a powerful interactive mode.
 


### PR DESCRIPTION
Adopts the xleak-style badge block (part of the cross-project badge standardization with doxx and xleak): 7 `for-the-badge` badges in two rows — CI / Crates.io / Downloads (lstr's accent: tree green `#4E9A06`), then License / Rust 1.70+ / Easy Install (`Homebrew | Scoop | WinGet`) / Platform. Replaces the three old flat-style badges. Docs-only.