### PR TITLE
Adopt devel branch workflow and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+# GitHub Dependabot configuration for lstr
+# See: https://docs.github.com/en/code-security/dependabot
+#
+# Added 2026-07-12 alongside the devel-branch workflow.
+
+
+version: 2
+updates:
+  # Rust dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "bgreenwell"
+    assignees:
+      - "bgreenwell"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+    # Group minor/patch updates to reduce PR noise. Majors are deliberately
+    # NOT grouped: bundling a breaking change in with 19 safe ones means one
+    # bad major (e.g. ratatui-image 8->10 needing a new system dependency,
+    # see bgreenwell/lstr#82) blocks the whole group instead of just itself.
+    # Ungrouped majors fall through to their own individual PRs instead.
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
+    reviewers:
+      - "bgreenwell"
+    assignees:
+      - "bgreenwell"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: Rust CI
 # It will trigger on any `push` to any branch, and on any `pull_request`.
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "devel" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "devel" ]
 
 # This defines the environment for the workflow. We set Cargo to use color output.
 env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,13 @@ cargo test test_name -- --nocapture     # single test
 ./scripts/test-dual-mode.sh             # classic + TUI consistency checks
 ```
 
-All three CI gates must pass before committing. Never develop on `main`:
-branch (`feature/...`, `fix/...`, `chore/...`), open a PR, merge after CI
-is green on Ubuntu, macOS, and Windows.
+All three CI gates must pass before committing.
+
+Branch model: `devel` is the default and integration branch; `main` tracks
+releases. Never commit directly to either — branch off `devel`
+(`feature/...`, `fix/...`, `chore/...`), open a PR to `devel`, and merge
+after CI is green on Ubuntu, macOS, and Windows. Releases merge `devel`
+into `main` and tag `vX.Y.Z` there (see `RELEASE_CHECKLIST.md`).
 
 ## Architecture
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -18,9 +18,9 @@ Use this checklist when preparing a new release of lstr. You can also create a G
 
 ## Create Release
 
-- [ ] Commit version bump: `git commit -m "chore: release X.Y.Z"`
-- [ ] Push to main: `git push`
-- [ ] Create version tag: `git tag vX.Y.Z`
+- [ ] Commit version bump on a release branch off `devel`: `git commit -m "chore: release X.Y.Z"`, PR to `devel`, merge after CI
+- [ ] Merge `devel` into `main` (PR or fast-forward) and wait for CI
+- [ ] Create version tag on `main`: `git tag vX.Y.Z`
 - [ ] Push tag: `git push origin vX.Y.Z`
 - [ ] Wait for GitHub Actions workflows to complete (~10-15 minutes)
 


### PR DESCRIPTION
Phase 0 of the dependency-modernization plan:

- `devel` created from `main` and set as the **default branch** (doxx's model): feature branches PR into `devel`; releases merge `devel` → `main` and tag there
- `ci.yml` push/PR triggers now cover both branches
- **Dependabot** enabled, config ported from doxx: weekly cargo + github-actions updates, minor/patch bumps grouped into one PR, majors deliberately ungrouped (one bad major shouldn't block the safe group — doxx#82 lesson). Targets `devel` implicitly as the default branch
- AGENTS.md and RELEASE_CHECKLIST.md updated for the new flow