### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-13
+
 ### Added
 
 - Interactive-mode search (`/`) supports glob wildcards (`*`, `?`) when the query contains one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "lstr"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lstr"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Brandon Greenwell <greenwell.brandon@gmail.com>"]
 edition = "2021"
 rust-version = "1.88"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -45,11 +45,11 @@ All of the following are now automated via GitHub Actions:
   - Manual: `cargo publish` from the tagged commit (not automated)
 
 - [ ] **AUR** package updated at [lstr-bin](https://aur.archlinux.org/packages/lstr-bin)
-  - Currently **community-maintained** (by Dominiquini; `lstr-git` by
-    bakatrouble is also community-maintained — see issue #15). Verify the
-    maintainer picks up the new version, or nudge on the AUR page.
-  - `.github/workflows/publish-aur.yml` is manual-only until co-maintainer
-    access is arranged; then restore its tag trigger.
+  - Co-maintainer access granted (see issue #15); `.github/workflows/publish-aur.yml`
+    now publishes automatically on tag push. This is its first real run —
+    verify it succeeds rather than assuming.
+  - `lstr-git` (by bakatrouble) is separately community-maintained; no
+    action needed from this pipeline.
 
 - [ ] **WinGet** manifest PR created to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
   - Automated by: `.github/workflows/publish-winget.yml`


### PR DESCRIPTION
## Summary
- Moves `[Unreleased]` CHANGELOG entries into a dated `[0.4.0]` section
- Bumps `Cargo.toml`/`Cargo.lock` version to 0.4.0
- Updates `RELEASE_CHECKLIST.md`'s stale AUR note (co-maintainer access is now in place, tag-trigger already restored)

Pre-release checklist already verified locally: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test`, `./scripts/validate-basic.sh`, `cargo run --release -- examples/sample-directory -L 2`, and `cargo publish --dry-run` all pass.

Tracks #72.

## Test plan
- [x] CI green on Ubuntu/macOS/Windows