### PR TITLE
fix: encode HTML file links

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -519,11 +519,19 @@ fn html_escape(s: &str) -> String {
     out
 }
 
-/// Joins path components with `/` regardless of platform, since an HTML
-/// `href` needs a URL-style separator even on Windows, where
-/// `Path::to_string_lossy` would otherwise yield backslashes.
+/// Encodes a relative filesystem path for an HTML `href`. Each component
+/// is encoded separately so `/` continues to delimit directories, while
+/// filename characters such as `#`, `?`, and `:` cannot change URL meaning.
 fn path_to_href(path: &std::path::Path) -> String {
-    path.components().map(|c| c.as_os_str().to_string_lossy()).collect::<Vec<_>>().join("/")
+    let mut url = Url::parse("https://lstr.invalid/").expect("static URL is valid");
+    {
+        let mut segments = url.path_segments_mut().expect("base URL accepts path segments");
+        segments.pop_if_empty();
+        for component in path.components() {
+            segments.push(&component.as_os_str().to_string_lossy());
+        }
+    }
+    format!(".{}", url.path())
 }
 
 /// Renders the node list as a self-contained HTML directory index (in the

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -706,6 +706,13 @@ fn test_html_output() -> Result<(), Box<dyn std::error::Error>> {
     // Angle brackets/ampersands must be escaped, not injected as markup.
     let weird_name = if cfg!(windows) { "weird name.txt" } else { "a&b<c>.txt" };
     fs::write(temp_dir.path().join(weird_name), "x")?;
+    let url_name = "space # percent%.txt";
+    fs::write(temp_dir.path().join(url_name), "x")?;
+    // A colon in the first path component must not become a URL scheme.
+    let dangerous_name = if cfg!(windows) { None } else { Some("javascript:alert(1).txt") };
+    if let Some(name) = dangerous_name {
+        fs::write(temp_dir.path().join(name), "x")?;
+    }
 
     let mut cmd = Command::cargo_bin("lstr")?;
     cmd.arg("--output").arg("html").arg("-s").arg(temp_dir.path());
@@ -715,11 +722,17 @@ fn test_html_output() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(html.starts_with("<!doctype html>"));
     assert!(html.contains("<li class=\"dir\"><details open><summary>sub"));
-    assert!(html.contains("<a href=\"sub/inner.txt\">inner.txt</a>"));
-    assert!(html.contains("1 directories, 2 files"));
+    assert!(html.contains("<a href=\"./sub/inner.txt\">inner.txt</a>"));
+    assert!(html.contains("<a href=\"./space%20%23%20percent%25.txt\">space # percent%.txt</a>"));
+    assert!(html.contains(if cfg!(windows) {
+        "1 directories, 3 files"
+    } else {
+        "1 directories, 4 files"
+    }));
     if !cfg!(windows) {
         assert!(html.contains("a&amp;b&lt;c&gt;.txt"));
         assert!(!html.contains("a&b<c>.txt"));
+        assert!(html.contains("<a href=\"./javascript:alert(1).txt\">javascript:alert(1).txt</a>"));
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Encode filesystem path segments before placing them in HTML `href` attributes.
- Prefix generated links with `./` so filename text cannot be interpreted as a URI scheme.
- Cover reserved URL characters and Unix `javascript:` filenames.

## Root cause

HTML escaping alone does not encode URL syntax: filenames containing `#`, `%`, or spaces generated links to the wrong resource, while a colon-prefixed filename could be treated as a URI scheme.

## Checks

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `cargo build --release`
