### PR TITLE
fix: preserve grouping when reversing sort

### DIFF
--- a/src/sort.rs
+++ b/src/sort.rs
@@ -76,14 +76,7 @@ pub fn sort_entries(entries: &mut Vec<DirEntry>, options: &SortOptions) {
     // comparisons avoid repeated metadata syscalls and string allocations.
     let mut decorated: Vec<(SortKey, DirEntry)> =
         std::mem::take(entries).into_iter().map(|e| (SortKey::new(&e, options), e)).collect();
-    decorated.sort_by(|(key_a, a), (key_b, b)| {
-        let result = compare_keyed(key_a, a, key_b, b, options);
-        if options.reverse {
-            result.reverse()
-        } else {
-            result
-        }
-    });
+    decorated.sort_by(|(key_a, a), (key_b, b)| compare_keyed(key_a, a, key_b, b, options));
     entries.extend(decorated.into_iter().map(|(_, entry)| entry));
 }
 
@@ -223,8 +216,9 @@ fn compare_keyed(
         }
     }
 
-    // Apply the primary sorting strategy
-    match options.sort_type {
+    // Apply the primary sorting strategy. Reverse affects ordering within a
+    // group, but not the grouping precedence established above.
+    let result = match options.sort_type {
         SortType::Name => compare_by_name_keyed(key_a, a, key_b, b, options),
         SortType::Size => key_a.size.cmp(&key_b.size),
         SortType::Modified => match (key_a.modified, key_b.modified) {
@@ -242,6 +236,11 @@ fn compare_keyed(
                 ext_cmp
             }
         }
+    };
+    if options.reverse {
+        result.reverse()
+    } else {
+        result
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -210,6 +210,32 @@ fn test_dirs_first_sorting() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn test_reverse_preserves_dirs_first_sorting() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    for name in ["dir-a", "dir-z"] {
+        fs::create_dir(temp_dir.path().join(name))?;
+    }
+    for name in ["file-a.txt", "file-z.txt"] {
+        fs::File::create(temp_dir.path().join(name))?;
+    }
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--dirs-first").arg("--reverse").arg(temp_dir.path());
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    let positions = ["dir-z", "dir-a", "file-z.txt", "file-a.txt"].map(|name| {
+        stdout
+            .lines()
+            .position(|line| line.contains(&format!("── {name}")))
+            .expect("entry should be listed")
+    });
+    assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{stdout}");
+
+    Ok(())
+}
+
+#[test]
 fn test_natural_sorting() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempdir()?;
     fs::File::create(temp_dir.path().join("file1.txt"))?;
@@ -366,6 +392,42 @@ fn test_dotfiles_first_sorting() -> Result<(), Box<dyn std::error::Error>> {
     assert!(dotfolder_line_pos < folder_line_pos);
     assert!(folder_line_pos < hidden_line_pos);
     assert!(hidden_line_pos < regular_line_pos);
+
+    Ok(())
+}
+
+#[test]
+fn test_reverse_preserves_dotfiles_first_sorting() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    for name in [".dotdir-a", ".dotdir-z", "dir-a", "dir-z"] {
+        fs::create_dir(temp_dir.path().join(name))?;
+    }
+    for name in [".dotfile-a", ".dotfile-z", "file-a.txt", "file-z.txt"] {
+        fs::File::create(temp_dir.path().join(name))?;
+    }
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--dotfiles-first").arg("-a").arg("--reverse").arg(temp_dir.path());
+    let output = cmd.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    let positions = [
+        ".dotdir-z",
+        ".dotdir-a",
+        "dir-z",
+        "dir-a",
+        ".dotfile-z",
+        ".dotfile-a",
+        "file-z.txt",
+        "file-a.txt",
+    ]
+    .map(|name| {
+        stdout
+            .lines()
+            .position(|line| line.contains(&format!("── {name}")))
+            .expect("entry should be listed")
+    });
+    assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{stdout}");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Keep directory and dotfile grouping stable when `--reverse` is used.
- Reverse the selected sort criterion within each group.
- Cover `--dirs-first --reverse` and `--dotfiles-first -a --reverse`.

## Root cause

The sort closure reversed the complete comparison result, including the grouping decisions made by `--dirs-first` and `--dotfiles-first`.

## Checks

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
