### PR TITLE
fix: retain file sizes with dirs-only du

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -102,15 +102,22 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         })
         .collect();
 
+    // Apply tree-aware sorting (preserves parent-child relationships)
+    let sort_options = args.common.to_sort_options();
+    sort::sort_entries_hierarchically(&mut entries, &sort_options);
+
+    // Cumulative sizes are computed over the full entry list, before output
+    // filtering or display limits, so `--dirs-only` does not change the size
+    // of the directory contents it displays.
+    let du_sizes = if args.du { Some(compute_cumulative_sizes(&entries)) } else { None };
+    let du_map = du_sizes.as_ref().map(|(map, _)| map);
+    let du_total = du_sizes.as_ref().map(|(_, total)| *total);
+
     // Filter before computing tree connectors so that skipped entries do
     // not count as siblings of the entries that are actually printed.
     if args.dirs_only {
         entries.retain(|entry| entry.file_type().is_some_and(|ft| ft.is_dir()));
     }
-
-    // Apply tree-aware sorting (preserves parent-child relationships)
-    let sort_options = args.common.to_sort_options();
-    sort::sort_entries_hierarchically(&mut entries, &sort_options);
 
     // The summary counts reflect the whole walked tree, including entries
     // hidden by --file-depth / --max-items (they are represented by the
@@ -123,12 +130,6 @@ pub fn run(args: &ViewArgs, ls_colors: &LsColors) -> anyhow::Result<()> {
         }
     }
 
-    // Cumulative sizes are computed over the full entry list, before any
-    // display limits, so a directory's size stays truthful even when its
-    // children are hidden.
-    let du_sizes = if args.du { Some(compute_cumulative_sizes(&entries)) } else { None };
-    let du_map = du_sizes.as_ref().map(|(map, _)| map);
-    let du_total = du_sizes.as_ref().map(|(_, total)| *total);
     let size_enabled = args.common.size || args.du;
 
     let nodes = apply_display_limits(entries, args.file_depth, args.max_items);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -768,3 +768,23 @@ fn test_du_cumulative_directory_sizes() -> Result<(), Box<dyn std::error::Error>
     assert!(json["report"]["total_size"].as_u64().expect("total present") >= 160);
     Ok(())
 }
+
+#[test]
+fn test_du_dirs_only_counts_hidden_file_contents() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    fs::create_dir(temp_dir.path().join("sub"))?;
+    fs::write(temp_dir.path().join("sub/payload.bin"), vec![b'x'; 100])?;
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("--du").arg("-d").arg("--output").arg("json").arg(temp_dir.path());
+    let json: serde_json::Value = serde_json::from_slice(&cmd.output()?.stdout)?;
+
+    let contents = json["contents"].as_array().expect("root contents");
+    assert_eq!(contents.len(), 1);
+    let sub = contents.iter().find(|e| e["name"] == "sub").expect("sub in json");
+    assert!(sub["size"].as_u64().expect("dir size present") >= 100);
+    assert_eq!(json["report"]["directories"], 1);
+    assert_eq!(json["report"]["files"], 0);
+    assert!(json["report"]["total_size"].as_u64().expect("total present") >= 100);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Compute `--du` totals before filtering files from `--dirs-only` output.
- Keep `--dirs-only` report counts unchanged while directory totals include hidden file contents.
- Add JSON regression coverage for a directory containing a hidden file.

## Root cause

The directory-only filter ran before cumulative-size computation, so every file contribution was removed from `--du -d` totals.

## Checks

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
