### PR TITLE
fix: show renamed files in git status

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -75,18 +75,33 @@ pub fn load_status(start_path: &Path) -> anyhow::Result<Option<GitRepoStatus>> {
 
     let mut cache = StatusCache::new();
     let mut opts = git2::StatusOptions::new();
-    opts.include_untracked(true).include_ignored(false).recurse_untracked_dirs(true);
+    opts.include_untracked(true)
+        .include_ignored(false)
+        .recurse_untracked_dirs(true)
+        .renames_head_to_index(true)
+        .renames_index_to_workdir(true);
 
     let statuses = repo.statuses(Some(&mut opts))?;
 
     for entry in statuses.iter() {
-        let Some(status) = git_to_file_status(entry.status()) else {
+        let entry_status = entry.status();
+        let Some(status) = git_to_file_status(entry_status) else {
             continue;
         };
 
-        if let Ok(path_str) = entry.path() {
+        let path = if entry_status.is_index_renamed() {
+            // `StatusEntry::path` is the old path for a rename, while the
+            // tree contains the new path that needs the status marker.
+            entry.head_to_index().and_then(|delta| delta.new_file().path().map(PathBuf::from))
+        } else if entry_status.is_wt_renamed() {
+            entry.index_to_workdir().and_then(|delta| delta.new_file().path().map(PathBuf::from))
+        } else {
+            entry.path().ok().map(PathBuf::from)
+        };
+
+        if let Some(path) = path {
             // Use the relative path directly as the key.
-            cache.insert(PathBuf::from(path_str), status);
+            cache.insert(path, status);
         }
     }
 
@@ -122,6 +137,9 @@ fn git_to_file_status(s: git2::Status) -> Option<FileStatus> {
     if s.is_conflicted() {
         return Some(FileStatus::Conflicted);
     }
+    if s.is_index_renamed() {
+        return Some(FileStatus::Renamed);
+    }
     if s.is_index_new() {
         return Some(FileStatus::New);
     }
@@ -131,23 +149,20 @@ fn git_to_file_status(s: git2::Status) -> Option<FileStatus> {
     if s.is_index_deleted() {
         return Some(FileStatus::Deleted);
     }
-    if s.is_index_renamed() {
-        return Some(FileStatus::Renamed);
-    }
     if s.is_index_typechange() {
         return Some(FileStatus::Typechange);
     }
     if s.is_wt_new() {
         return Some(FileStatus::Untracked);
     }
+    if s.is_wt_renamed() {
+        return Some(FileStatus::Renamed);
+    }
     if s.is_wt_modified() {
         return Some(FileStatus::Modified);
     }
     if s.is_wt_deleted() {
         return Some(FileStatus::Deleted);
-    }
-    if s.is_wt_renamed() {
-        return Some(FileStatus::Renamed);
     }
     if s.is_wt_typechange() {
         return Some(FileStatus::Typechange);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -144,12 +144,18 @@ fn test_git_status_flag() -> Result<(), Box<dyn std::error::Error>> {
         .output()?;
 
     fs::write(temp_path.join("committed.txt"), "initial content")?;
-    Command::new("git").args(["add", "committed.txt"]).current_dir(temp_path).output()?;
+    fs::write(temp_path.join("old-name.txt"), vec![b'r'; 1024])?;
+    Command::new("git")
+        .args(["add", "committed.txt", "old-name.txt"])
+        .current_dir(temp_path)
+        .output()?;
     Command::new("git").args(["commit", "-m", "initial commit"]).current_dir(temp_path).output()?;
 
     fs::write(temp_path.join("committed.txt"), "modified content")?;
     fs::write(temp_path.join("staged.txt"), "staged")?;
     Command::new("git").args(["add", "staged.txt"]).current_dir(temp_path).output()?;
+    fs::rename(temp_path.join("old-name.txt"), temp_path.join("new-name.txt"))?;
+    Command::new("git").args(["add", "-A"]).current_dir(temp_path).output()?;
     fs::write(temp_path.join("untracked.txt"), "untracked")?;
 
     let mut cmd = Command::cargo_bin("lstr")?;
@@ -159,7 +165,19 @@ fn test_git_status_flag() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::is_match(r"M\s+.*committed\.txt").unwrap())
         .stdout(predicate::str::is_match(r"A\s+.*staged\.txt").unwrap())
+        .stdout(predicate::str::is_match(r"R\s+.*new-name\.txt").unwrap())
         .stdout(predicate::str::is_match(r"\?\s+.*untracked\.txt").unwrap());
+
+    let mut cmd = Command::cargo_bin("lstr")?;
+    cmd.arg("-G").arg("-a").arg("--output").arg("json").arg(temp_path);
+    let json: serde_json::Value = serde_json::from_slice(&cmd.output()?.stdout)?;
+    let renamed = json["contents"]
+        .as_array()
+        .expect("root contents")
+        .iter()
+        .find(|entry| entry["name"] == "new-name.txt")
+        .expect("renamed file should be listed");
+    assert_eq!(renamed["git_status"], "R");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Enable libgit2 rename detection for staged and worktree changes.
- Cache renamed entries under their new path so the visible tree receives the status marker.
- Cover staged rename status in text and JSON output.

## Root cause

Rename detection was disabled. After enabling it, `StatusEntry::path()` still supplied the old rename path, which does not exist in the rendered tree.

## Checks

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
