### PR TITLE
ci: modernize ci.yml and docs.yml to match doxx's current template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,60 +1,43 @@
-# This is the name of the workflow that will be displayed on GitHub
-name: Rust CI
+name: CI
 
-# This section defines when the workflow will run.
-# It will trigger on any `push` to any branch, and on any `pull_request`.
 on:
   push:
-    branches: [ "main", "devel" ]
+    branches: [main, devel]
   pull_request:
-    branches: [ "main", "devel" ]
+    branches: [main, devel]
 
-# This defines the environment for the workflow. We set Cargo to use color output.
 env:
   CARGO_TERM_COLOR: always
 
-# This section defines the jobs to be run. We have one job called "build".
 jobs:
-  build:
-    # The name that will be displayed for this job on GitHub
-    name: Test on ${{ matrix.os }}
-    
-    # This job will run on multiple operating systems to ensure cross-platform compatibility
+  test:
+    name: Build and Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
-    # These are the individual steps the job will execute in order
     steps:
-    # 1. Check out the repository code so the workflow can access it
-    - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v5
 
-    # 2. Cache the cargo directories to speed up future builds
-    - name: Cache cargo dependencies
-      uses: actions/cache@v6
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
-    # 3. Check that the code is formatted correctly
-    - name: Check formatting
-      run: cargo fmt -- --check
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
 
-    # 4. Run Clippy to check for common mistakes and enforce idiomatic Rust
-    #    The `-D warnings` flag treats all warnings as errors, failing the build.
-    - name: Run Clippy
-      run: cargo clippy -- -D warnings
+      - name: Check formatting (Unix only)
+        if: matrix.os != 'windows-latest'
+        run: cargo fmt --all -- --check
 
-    # 5. Run the tests (if any are defined)
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Lint with Clippy
+        run: cargo clippy --all-targets -- -D warnings
 
-    # 6. Build the project in release mode to ensure it compiles
-    - name: Build
-      run: cargo build --release --verbose
+      - name: Run tests
+        run: cargo test
+
+      - name: Check build
+        run: cargo build --release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,60 +1,71 @@
-# .github/workflows/docs.yml
-
 name: Deploy Documentation
 
 on:
-  # Runs on pushes targeting the `main` branch
   push:
-    branches: ["main"]
+    branches: ["main", "devel"]
 
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
+    if: ${{ github.actor == 'bgreenwell' }}
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
+        uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Build documentation
         run: cargo doc --no-deps
 
-      # NEW STEP: Create the redirect page
       - name: Create redirect page
         run: echo '<meta http-equiv="refresh" content="0; url=lstr">' > target/doc/index.html
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          # Upload entire directory
-          path: './target/doc'
+        id: pages
+        uses: actions/configure-pages@v6
+        continue-on-error: true
 
-  # Deployment job
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./target/doc"
+
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: success()
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        continue-on-error: true
+
+      - name: Pages deployment status
+        run: |
+          if [ "${{ steps.deployment.outcome }}" == "failure" ]; then
+            echo "::warning::GitHub Pages deployment failed. Please enable Pages in repository settings:"
+            echo "::warning::1. Go to Settings > Pages"
+            echo "::warning::2. Set Source to 'GitHub Actions'"
+            echo "::warning::3. Re-run this workflow"
+          else
+            echo "Documentation deployed successfully!"
+          fi


### PR DESCRIPTION
## Summary
- Replace the actions-rs/toolchain-based CI template with doxx's current one: dtolnay/rust-toolchain, Swatinem/rust-cache, Unix-only fmt check, `clippy --all-targets`, current action pins
- Add the actor guard and deployment-failure reporting from doxx's docs.yml
- Deliberately did not add doxx's Nix build step - lstr's flake.nix only defines a devShell, not a buildable package, so `nix build` would fail
- release.yml and publish-aur/scoop/winget.yml already matched doxx exactly (cargo-dist 0.30.2, same pins) - no changes needed there

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (this is a stricter check than the old `cargo clippy` without `--all-targets` - passes clean)
- [x] `cargo test` (29 passed)
- [x] Both edited workflow files validated with `yaml.safe_load`
- [ ] CI green on Linux/macOS/Windows